### PR TITLE
make_dashboards.py use a copy of the gridpos object to be able to modify it

### DIFF
--- a/make_dashboards.py
+++ b/make_dashboards.py
@@ -234,7 +234,9 @@ def add_row(y, panels, row, args):
     for p in row["panels"]:
         gridpos = {}
         if "gridPos" in p:
-            gridpos = p["gridPos"]
+            gridpos = dict(p["gridPos"])
+        else:
+            gridpos = {}
         w = panel_width(gridpos, p)
         if  w + x > 24:
             x = 0


### PR DESCRIPTION
This patch solves an issue with using the gridpos to specify sizes.
it now uses a copy of the object, instead of the original one.