### PR TITLE
prometheus.rules.yml: Change the noCQL alerts to info

### DIFF
--- a/prometheus/prom_rules/prometheus.rules.yml
+++ b/prometheus/prom_rules/prometheus.rules.yml
@@ -191,9 +191,9 @@ groups:
       summary: Instance {{ $labels.instance }} low disk space
   - alert: NoCql
     expr: scylla_manager_healthcheck_cql_status == -1
-    for: 30s
+    for: 5m
     labels:
-      severity: "warn"
+      severity: "info"
     annotations:
       description: '{{ $labels.host }} has denied CQL connection for more than 30 seconds.'
       summary: Instance {{ $labels.host }} no CQL connection


### PR DESCRIPTION
This patch makes the noCQL alert, less noisy, it change the severity to info and and set the the time duration to minimal 5 minutes without connectivity.

Fixes #2105