### PR TITLE
scylla_monitoring_install_ami: adopt to the new scylla monitoring version tags

### DIFF
--- a/packer/files/scylla_monitoring_install_ami
+++ b/packer/files/scylla_monitoring_install_ami
@@ -121,8 +121,8 @@ def install_monitoring(version):
         run('sudo -u {_USER} curl -L -o {_HOME}/scylla-monitoring.tar.gz  https://github.com/scylladb/scylla-monitoring/archive/refs/heads/master.tar.gz'.format(_HOME=HOME_DIR, _USER=USER))
         name = 'scylla-monitoring-master'
     else:
-        run('sudo -u {_USER} curl -L -o {_HOME}/scylla-monitoring.tar.gz  https://github.com/scylladb/scylla-monitoring/archive/refs/tags/scylla-monitoring-{VERSION}.tar.gz'.format(VERSION=version, _HOME=HOME_DIR, _USER=USER))
-        name = 'scylla-monitoring-scylla-monitoring-{VERSION}'.format(VERSION=version)
+        run('sudo -u {_USER} curl -L -o {_HOME}/scylla-monitoring.tar.gz  https://github.com/scylladb/scylla-monitoring/archive/refs/tags/{VERSION}.tar.gz'.format(VERSION=version, _HOME=HOME_DIR, _USER=USER))
+        name = 'scylla-monitoring-{VERSION}'.format(VERSION=version)
     run('sudo -u {_USER} tar -xvf {_HOME}/scylla-monitoring.tar.gz -C {_HOME}/')
     run('sudo -u {_USER} {_COPY_OR_MOVE} {_HOME}/{NAME} {_HOME}/scylla-grafana-monitoring-scylla-monitoring'.format(NAME=name, _HOME=HOME_DIR, _USER=USER, _COPY_OR_MOVE=COPY_OR_MOVE))
 


### PR DESCRIPTION
The release tags are not of the format major.minor.patch (e.g. 4.7.0)
This patch modify the installation script to use the new format