### PR TITLE
types: Add unit types to the keyspace table

### DIFF
--- a/grafana/types.json
+++ b/grafana/types.json
@@ -2770,8 +2770,97 @@
                 "custom":{
                    "align":null,
                    "filterable":true
-                }
-              }
+                },
+               "overrides": [
+                  {
+                     "matcher": {
+                        "id": "byName",
+                        "options": "Disk space"
+                     },
+                     "properties": [
+                        {
+                           "id": "unit",
+                           "value": "decbytes"
+                        }
+                     ]
+                  },
+                  {
+                     "matcher": {
+                        "id": "byName",
+                        "options": "W P95"
+                     },
+                     "properties": [
+                        {
+                           "id": "unit",
+                           "value": "µs"
+                        }
+                     ]
+                  },
+                  {
+                     "matcher": {
+                        "id": "byName",
+                        "options": "W P99"
+                     },
+                     "properties": [
+                        {
+                           "id": "unit",
+                           "value": "µs"
+                        }
+                     ]
+                  },
+                  {
+                     "matcher": {
+                        "id": "byName",
+                        "options": "R P95"
+                     },
+                     "properties": [
+                        {
+                           "id": "unit",
+                           "value": "µs"
+                        }
+                     ]
+                  },
+                  {
+                     "matcher": {
+                        "id": "byName",
+                        "options": "R P99"
+                     },
+                     "properties": [
+                        {
+                           "id": "unit",
+                           "value": "µs"
+                        }
+                     ]
+                  },
+                  {
+                     "matcher": {
+                        "id": "byName",
+                        "options": "writes/s"
+                     },
+                     "properties": [
+                        {
+                           "id": "unit",
+                           "value": "sishort"
+                        }
+                     ]
+                  },
+                  {
+                     "matcher": {
+                        "id": "byName",
+                        "options": "reads/s"
+                     },
+                     "properties": [
+                        {
+                           "id": "unit",
+                           "value": "sishort"
+                        }
+                     ]
+                  }
+               ]
+              },
+              "mappings": [],
+              "unit": "short",
+              "decimals": 0
           },
           "gridPos": {
             "h": 8,
@@ -2824,10 +2913,10 @@
                   "ks 1": "keyspace",
                   "cf": "table",
                   "Value #A": "sstables",
-                  "Value #B": "writes/2",
+                  "Value #B": "writes/s",
                   "Value #C": "W P95",
                   "Value #D": "W P99",
-                  "Value #E": "reads/2",
+                  "Value #E": "reads/s",
                   "Value #F": "R P95",
                   "Value #G": "R P99",
                   "Value #H": "Disk space"


### PR DESCRIPTION
This patch adds type to the tables table in the keyspace dashboard

![image](https://github.com/user-attachments/assets/5b8827d8-a75f-4bb9-8d6e-68d1ad9a58a2)

Fixes #2550