### PR TITLE
advanced: Add stalls graph

### DIFF
--- a/grafana/scylla-advanced.template.json
+++ b/grafana/scylla-advanced.template.json
@@ -405,11 +405,22 @@
                         "description": "Number of write requests that failed due to an 'unavailable' error"
                     },
                     {
-                        "class": "text_panel",
-                        "content": "##  ",
-                        "mode": "markdown",
+                        "class": "graph_panel",
                         "span": 4,
-                        "style": {}
+                        "targets": [
+                            {
+                                "expr": "$topbottom([[filter_limit]], avg(rate(scylla_stall_detector_reported{instance=~\"[[node]]\" ,cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]]))",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 30
+                            }
+                        ],
+                        "options": {
+                            "class":"desc_tooltip_options"
+                        },
+                        "title": "Stall per seconds by [[by]]",
+                        "description": "Number of Stalls per seconds."
                     }
                  ],
                 "title": "New row"


### PR DESCRIPTION
This patch adds a graph for the number of stalls per second to the advanced dashboard.
![image](https://github.com/user-attachments/assets/1b1991e4-2ce5-4fac-bf95-26f9db467090)

Fixes #2558