### PR TITLE
Use bridge network and monitoring Grafana

### DIFF
--- a/kill-all.sh
+++ b/kill-all.sh
@@ -113,3 +113,8 @@ if [ -z $STACK_ID ]; then
 	./kill-container.sh -b thanos
 	./kill-container.sh -b datadog-agent
 fi
+HOST_NETWORK="monitor-net"
+if [ "$STACK_ID" != "" ]; then
+    HOST_NETWORK="$HOST_NETWORK$STACK_ID"
+fi
+docker network rm $HOST_NETWORK  >/dev/null 2>&1 || true

--- a/prometheus/prometheus.consul.yml.template
+++ b/prometheus/prometheus.consul.yml.template
@@ -217,7 +217,12 @@ scrape_configs:
 
 - job_name: 'prometheus'
   # Override the global default and scrape targets from this job every 5 seconds.
-  scrape_interval: 5s
+  scrape_interval: 30s
   static_configs:
     - targets:
       - localhost:9090
+- job_name: 'grafana'
+  scrape_interval: 30s
+  static_configs:
+    - targets:
+      - GRAFANA_ADDRESS

--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -167,8 +167,12 @@ scrape_configs:
       replacement: 'cluster'
 
 - job_name: 'prometheus'
-  # Override the global default and scrape targets from this job every 5 seconds.
-  scrape_interval: 5s
+  scrape_interval: 30s
   static_configs:
     - targets:
       - localhost:9090
+- job_name: 'grafana'
+  scrape_interval: 30s
+  static_configs:
+    - targets:
+      - GRAFANA_ADDRESS


### PR DESCRIPTION
 "Quis custodiet ipsos custodes?"

Grafana server itself is a crucial part of the system, and we need to monitor it as well.
This series adds grafana as a Prometheus target.

To overcome the dependency loop, we create a network and use the container name.
In the future, we may migrate all IP addresses to utilize this scheme.
 
 Fixes #2632