### PR TITLE
vector-store: add Memory percentage stat

### DIFF
--- a/grafana/scylla-vector-store.template.json
+++ b/grafana/scylla-vector-store.template.json
@@ -242,10 +242,51 @@
                                         {
                                             "color": "green",
                                             "value": null
+                                        },
+                                        {
+                                            "color": "red",
+                                            "value": 0.8
                                         }
                                     ]
                                 },
-                                "unit": "decbytes"
+                                "unit": "percentunit",
+                                "min": 0,
+                                "max": 1,
+                                "decimals": 0
+                            },
+                            "overrides": []
+                        },
+                        "gridPos": {
+                            "w": 3,
+                            "h": 5
+                        },
+                        "targets": [
+                            {
+                                "expr": "1-avg(node_memory_MemAvailable_bytes{job=\"vector_store_os\"})/avg(node_memory_MemTotal_bytes{job=\"vector_store_os\"})",
+                                "intervalFactor": 1,
+                                "legendFormat": "Used",
+                                "refId": "A",
+                                "step": 40
+                            }
+                        ],
+                        "title": "Memory % Usage"
+                    },
+                    {
+                        "class": "small_stat_area",
+                        "fieldConfig": {
+                            "defaults": {
+                                "mappings": [],
+                                "thresholds": {
+                                    "mode": "absolute",
+                                    "steps": [
+                                        {
+                                            "color": "green",
+                                            "value": null
+                                        }
+                                    ]
+                                },
+                                "unit": "decbytes",
+                                "min": 0
                             },
                             "overrides": []
                         },


### PR DESCRIPTION
This patch adds a stats panel for cpu percentage usage, it also set the minimum value for the usage in bytes so it will be clearer.

<img width="2195" height="550" alt="image" src="https://github.com/user-attachments/assets/2db67658-36ad-4823-ad50-c8f4fb152193" />
