### PR TITLE
scylla-overview: Show all dc disk usages

### DIFF
--- a/grafana/scylla-overview.template.json
+++ b/grafana/scylla-overview.template.json
@@ -215,16 +215,16 @@
                         },
                         "targets": [
                             {
-                                "expr": "1-avg(node_filesystem_avail_bytes{mountpoint=\"$mount_point\",  dc=~\"$dc\", instance=~\"$node\"}) by ([[by]])/Avg(node_filesystem_size_bytes{mountpoint=\"$mount_point\", dc=~\"$dc\", instance=~\"$node\"}) by ([[by]])",
+                                "expr": "1-(node_filesystem_avail_bytes{mountpoint=\"$mount_point\",  dc=~\"$dc\", instance=~\"$node\"})/(node_filesystem_size_bytes{mountpoint=\"$mount_point\", dc=~\"$dc\", instance=~\"$node\"})",
                                 "intervalFactor": 1,
-                                "legendFormat": "Avg Usage {{instance}}",
+                                "legendFormat": "{{dc}} {{instance}}",
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1
                             }
                         ],
-                        "description": "The average Disk usage per [[by]]",
-                        "title": "Average Disk Usage"
+                        "description": "Disk percente usage",
+                        "title": "Disk Usage"
                     },
                     {
                         "class": "graph_panel_int",


### PR DESCRIPTION
Showing the average disk usage in the DC section is confusing. Instead, show a graph of all the nodes in that DC (it should be a reasonable number).

For a specific node, look at the node table.

<img width="322" height="291" alt="image" src="https://github.com/user-attachments/assets/aa8732a9-8e96-4e4c-9dff-c6b343057fb5" />

Fixes #2666