### PR TITLE
scylla_monitoring_install_ami: Allow cql connection tables

### DIFF
--- a/packer/files/scylla_monitoring_install_ami
+++ b/packer/files/scylla_monitoring_install_ami
@@ -108,7 +108,7 @@ def setup_monitoring():
     run('sudo -u {_USER} {_COPY_OR_MOVE} {_HOME}/scylla-grafana-monitoring-scylla-monitoring/prometheus/rule_config.yml {_HOME}/scylla-grafana-monitoring-scylla-monitoring/prometheus/rule_config.original.yml')
     run('sudo -u {_USER} {_COPY_OR_MOVE} {_HOME}/rule_config.yml {_HOME}/scylla-grafana-monitoring-scylla-monitoring/prometheus/')
     run('sudo -u {_USER} {_COPY_OR_MOVE} {_HOME}/UA.sh {_HOME}/scylla-grafana-monitoring-scylla-monitoring/')
-    run('sudo -u {_USER} ./generate-dashboards.sh -D -F -P "no-version-check" -P "no-cql-connection" -P "no-your-pannels"')
+    run('sudo -u {_USER} ./generate-dashboards.sh -D -F -P "no-version-check" -P "no-your-pannels"')
 
 def install_monitoring(version):
     if version == 'master':


### PR DESCRIPTION
With the cloud moving to a cql monitoring user, generated image would contain the cql tables that uses that connection.