### PR TITLE
Switch to grafana pre-defined units

### DIFF
--- a/grafana/alternator.template.json
+++ b/grafana/alternator.template.json
@@ -928,7 +928,7 @@
                         "title": "Cache Misses"
                     },
                     {
-                        "class": "wpm_panel",
+                        "class": "wps_panel",
                         "description": "Requests that Scylla tried to write but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
                         "span": 3,
                         "targets": [
@@ -940,10 +940,10 @@
                                 "step": 10
                             }
                         ],
-                        "title": "Write Timeouts/Minutes by [[by]]"
+                        "title": "Write Timeouts/s by [[by]]"
                     },
                     {
-                        "class": "rpm_panel",
+                        "class": "rps_panel",
                         "description": "Requests that Scylla tried to read but timed out. Timeouts are counted in the node that received the request (the coordinator), not at the replicas.",
                         "span": 3,
                         "targets": [
@@ -955,7 +955,7 @@
                                 "step": 10
                             }
                         ],
-                        "title": "Read Timeouts/Minutes by [[by]]"
+                        "title": "Read Timeouts/s by [[by]]"
                     },
                     {
                         "class": "graph_panel",
@@ -973,7 +973,7 @@
                         "title": "HTTP Opened connections by [[by]]"
                     },
                     {
-                        "class": "rpm_panel",
+                        "class": "connectionsps_panel",
                         "description": "Rate of new HTTP connections creation. High number may indicate a problem",
                         "span": 3,
                         "targets": [
@@ -985,14 +985,6 @@
                                 "step": 10
                             }
                         ],
-                        "fieldConfig": {
-                            "defaults": {
-                              "class": "fieldConfig_defaults",
-                              "decimals": 0,
-                              "unit": "si:C/s"
-                            },
-                            "overrides": []
-                         },
                         "title": "HTTP New connections by [[by]]"
                     },
                     {

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -1716,7 +1716,7 @@
       "fieldConfig": {
         "defaults": {
           "class": "fieldConfig_defaults",
-          "unit": "si:ops/s"
+          "unit": "ops"
         },
         "overrides": []
       }
@@ -1873,7 +1873,7 @@
       "fieldConfig": {
         "defaults": {
           "class": "fieldConfig_defaults",
-          "unit": "si:writes/s"
+          "unit": "wps"
         },
         "overrides": []
      }
@@ -1883,7 +1883,7 @@
       "fieldConfig": {
         "defaults": {
           "class": "fieldConfig_defaults",
-          "unit": "si:reads/s"
+          "unit": "rps"
         },
         "overrides": []
       }
@@ -1893,37 +1893,17 @@
       "fieldConfig": {
         "defaults": {
           "class": "fieldConfig_defaults",
-          "unit": "si:requests/s"
+          "unit": "reqps"
         },
         "overrides": []
       }
-   },
-   "wpm_panel":{
-      "class":"iops_panel",
-      "fieldConfig": {
-        "defaults": {
-          "class": "fieldConfig_defaults",
-          "unit": "si:writes/s"
-        },
-        "overrides": []
-      }
-   },
-   "rpm_panel":{
-      "class":"iops_panel",
-      "fieldConfig": {
-        "defaults": {
-          "class": "fieldConfig_defaults",
-          "unit": "si:reads/m"
-        },
-        "overrides": []
-     }
    },
    "reads_panel":{
       "class":"iops_panel",
       "fieldConfig": {
         "defaults": {
           "class": "fieldConfig_defaults",
-          "unit": "si:reads"
+          "unit": "rps"
         },
         "overrides": []
       }
@@ -1933,7 +1913,18 @@
       "fieldConfig": {
         "defaults": {
           "class": "fieldConfig_defaults",
-          "unit": "si:writes"
+          "unit": "wps"
+        },
+        "overrides": []
+      }
+   },
+   "connectionsps_panel":{
+      "class":"iops_panel",
+      "fieldConfig": {
+        "defaults": {
+          "class": "fieldConfig_defaults",
+          "decimals": 0,
+          "unit": "si:C/s"
         },
         "overrides": []
       }


### PR DESCRIPTION
This patch switch from the custom units to Grafana's built-in units for read, write, requests and ops.
It solves the issue of a low rate that looks like millions.
Before
<img width="2212" height="721" alt="image" src="https://github.com/user-attachments/assets/2f097a57-46c1-4c24-bc44-ddd5c74c24c1" />
After
<img width="2536" height="900" alt="image" src="https://github.com/user-attachments/assets/26ae355c-93a7-4445-a79d-681ef08ee86a" />

Fixes #2668