### PR TITLE
Remove conditional from open source and old versions

### DIFF
--- a/grafana/alternator.template.json
+++ b/grafana/alternator.template.json
@@ -398,7 +398,7 @@
                                 "expr": "$func(rate(scylla_alternator_batch_item_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchWriteItem\"}[$__rate_interval])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
-                                "dashversion":[">6.2", ">2025.1"],
+                                "dashversion":[">2025.1"],
                                 "refId": "A",
                                 "step": 1
                             },
@@ -406,7 +406,7 @@
                                 "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchWriteItemSize\"}[$__rate_interval])) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
-                                "dashversion":["<6.2", "<2025.1"],
+                                "dashversion":["<2025.1"],
                                 "refId": "A",
                                 "step": 1
                             }
@@ -421,7 +421,7 @@
                             {
                                 "expr": "$func(rate(scylla_alternator_batch_item_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchWriteItem\"}[$__rate_interval])) by ([[by]])/$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchWriteItem\"}[$__rate_interval])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "dashversion":[">6.2", ">2025.1"],
+                                "dashversion":[">2025.1"],
                                 "legendFormat": "",
                                 "refId": "A",
                                 "step": 1
@@ -429,7 +429,7 @@
                             {
                                 "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchWriteItemSize\"}[$__rate_interval])) by ([[by]])/$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchWriteItem\"}[$__rate_interval])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "dashversion":["<6.2", "<2025.1"],
+                                "dashversion":["<2025.1"],
                                 "legendFormat": "",
                                 "refId": "A",
                                 "step": 1
@@ -459,7 +459,7 @@
                             {
                                 "expr": "$func(rate(scylla_alternator_batch_item_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchGetItem\"}[$__rate_interval])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "dashversion":[">6.2", ">2025.1"],
+                                "dashversion":[">2025.1"],
                                 "legendFormat": "",
                                 "refId": "A",
                                 "step": 1
@@ -467,7 +467,7 @@
                             {
                                 "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchGetItemSize\"}[$__rate_interval])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "dashversion":["<6.2", "<2025.1"],
+                                "dashversion":["<2025.1"],
                                 "legendFormat": "",
                                 "refId": "A",
                                 "step": 1
@@ -483,7 +483,7 @@
                             {
                                 "expr": "$func(rate(scylla_alternator_batch_item_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchGetItem\"}[$__rate_interval])) by ([[by]])/$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchGetItem\"}[$__rate_interval])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "dashversion":[">6.2", ">2025.1"],
+                                "dashversion":[">2025.1"],
                                 "legendFormat": "",
                                 "refId": "A",
                                 "step": 1
@@ -491,7 +491,7 @@
                             {
                                 "expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchGetItemSize\"}[$__rate_interval])) by ([[by]])/$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchGetItem\"}[$__rate_interval])) by ([[by]])",
                                 "intervalFactor": 1,
-                                "dashversion":["<6.2", "<2025.1"],
+                                "dashversion":["<2025.1"],
                                 "legendFormat": "",
                                 "refId": "A",
                                 "step": 1

--- a/grafana/scylla-advanced.template.json
+++ b/grafana/scylla-advanced.template.json
@@ -30,7 +30,7 @@
             {
                 "class": "row",
                 "height": "25px",
-                "dashversion":[">5.4", ">2023.1"],
+                "dashversion":[">2023.1"],
                 "panels": [
                     {
                         "class": "percentunit_panel",
@@ -736,7 +736,7 @@
             },
             {
                 "class": "row",
-                "dashversion":[">6.0", ">2024.2"],
+                "dashversion":[">2024.2"],
                 "panels": [
                     {
                         "class": "collapsible_row_panel",
@@ -748,7 +748,7 @@
             },
             {
                 "class": "row",
-                "dashversion":[">6.0", ">2024.2"],
+                "dashversion":[">2024.2"],
                 "panels": [
                     {
                         "class": "graph_panel",
@@ -975,7 +975,7 @@
                 },
                 {
                     "class": "template_variable_all",
-                    "dashversion":[">5.4", ">2024.1"],
+                    "dashversion":[">2024.1"],
                     "label": "iogroup",
                     "name": "iogroup",
                     "hide": 0,

--- a/grafana/scylla-cql.template.json
+++ b/grafana/scylla-cql.template.json
@@ -468,14 +468,14 @@
                               "refId": "A",
                               "queryText": "select keyspace_name, table_name, partition_key, partition_size, compaction_time, rows from system.large_partitions",
                               "queryHost": "$original_ip",
-                              "dashversion":["<6.0", "<2024.2"],
+                              "dashversion":["<2024.2"],
       						  "allHosts": true
                             },
                             {
                               "refId": "A",
                               "queryText": "select keyspace_name, table_name, partition_key, partition_size, compaction_time, rows, dead_rows, range_tombstones from system.large_partitions",
                               "queryHost": "$original_ip",
-                              "dashversion":[">6.0", ">2024.2"],
+                              "dashversion":[">2024.2"],
                               "allHosts": true
                             }
                           ],

--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -8,7 +8,7 @@
             },
             {
                 "class": "row",
-                "dashversion":["<6.0", "<2024.2"],
+                "dashversion":["<2024.2"],
                 "panels": [
                     {
                         "class": "percent_panel",
@@ -77,7 +77,7 @@
             },
            {
            "class": "row",
-           "dashversion":[">6.0", ">2024.2"],
+           "dashversion":[">2024.2"],
                 "panels": [
                  {
                         "class": "percent_panel",
@@ -170,7 +170,7 @@
          },
          {
                 "class": "row",
-                "dashversion":[">6.0", ">2024.2"],
+                "dashversion":[">2024.2"],
                 "panels": [
                     {
                         "class": "collapsible_row_panel",
@@ -181,7 +181,7 @@
             },
             {
             "class": "row",
-            "dashversion":[">6.0", ">2024.2"],
+            "dashversion":[">2024.2"],
                  "panels": [
                      {
                      "title": "Tablets over time per [[by]]",
@@ -843,7 +843,7 @@
                         "class": "text_panel",
                         "content": "",
                         "mode": "markdown",
-                        "dashversion":["<2024.1", ">5.0"],
+                        "dashversion":["<2024.1"],
                         "span": 6
                     },
                     {

--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -2469,7 +2469,6 @@
                     {
                         "class": "bps_panel",
                         "span": 3,
-                        "dashversion":[">5.3", ">2022.1"],
                         "description": "Bytes received in CQL messages",
                         "targets": [
                             {
@@ -2486,7 +2485,6 @@
                     {
                         "class": "bps_panel",
                         "span": 3,
-                        "dashversion":[">5.3", ">2022.1"],
                         "description": "Average CQL message size (received)",
                         "targets": [
                             {
@@ -2503,7 +2501,6 @@
                     {
                         "class": "bps_panel",
                         "span": 3,
-                        "dashversion":[">5.3", ">2022.1"],
                         "description": "Bytes sent in CQL messages",
                         "targets": [
                             {
@@ -2520,7 +2517,6 @@
                     {
                         "class": "bps_panel",
                         "span": 3,
-                        "dashversion":[">5.3", ">2022.1"],
                         "targets": [
                             {
                                 "expr": "$topbottom([[filter_limit]], sum(rate(scylla_transport_cql_response_bytes{kind=~\"$kind\",instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]])/sum(rate(scylla_transport_cql_requests_count{kind=~\"$kind\",instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]]))",
@@ -2537,7 +2533,6 @@
                     {
                         "class": "bytes_panel",
                         "span": 3,
-                        "dashversion":[">5.3", ">2022.1"],
                         "targets": [
                             {
                                 "expr": "$topbottom([[filter_limit]], sum(rate(scylla_transport_cql_request_bytes{kind=~\"QUERY|EXECUTE\",instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_write_latency_summary_count{instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]]) or on([[by]]) sum(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]])))",
@@ -2554,7 +2549,6 @@
                     {
                         "class": "bytes_panel",
                         "span": 3,
-                        "dashversion":[">5.3", ">2022.1"],
                         "targets": [
                             {
                                 "expr": "$topbottom([[filter_limit]], sum(rate(scylla_transport_cql_response_bytes{kind=~\"QUERY|EXECUTE\",instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_read_latency_summary_count{instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]]) or on ([[by]]) sum(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]])))",
@@ -2668,7 +2662,6 @@
                 {
                     "class": "template_variable_all",
                     "label": "cql_kind",
-                    "dashversion":[">5.3", ">2022.1"],
                     "name": "kind",
                     "query": "label_values(scylla_transport_cql_requests_count{cluster=\"$cluster\"}, kind)",
                     "sort": 3

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -1206,7 +1206,7 @@
                {
                   "expr":"(sum(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\", op !~\"Batch.*\"}[$__rate_interval])) or vector(0))+ on() (sum(rate(scylla_alternator_batch_item_count{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) or vector(0))",
                   "intervalFactor":1,
-                  "dashversion":[">6.2", ">2025.1"],
+                  "dashversion":[">2025.1"],
                   "refId":"A",
                   "instant":true,
                   "step":40
@@ -1214,7 +1214,7 @@
                {
                   "expr":"(sum(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\", op !~\"Batch.*Item\"}[$__rate_interval])) or vector(0))",
                   "intervalFactor":1,
-                  "dashversion":["<6.2", "<2025.1"],
+                  "dashversion":["<2025.1"],
                   "refId":"A",
                   "instant":true,
                   "step":40
@@ -3811,7 +3811,7 @@
             "interval":"",
             "refId":"E",
             "instant":true,
-            "dashversion":[">5.2", ">2023.1"],
+            "dashversion":[">2023.1"],
             "format":"table"
          },
          {
@@ -4248,7 +4248,7 @@
                   "id":"byName",
                   "options":"Value #E"
                },
-               "dashversion":[">5.2", ">2023.1"],
+               "dashversion":[">2023.1"],
                "properties":[
                   {
                      "id":"custom.displayMode",
@@ -5751,7 +5751,7 @@
             "class":"ops_annotation"
          },
          {
-            "dashversion":[">5.2", ">2023.1"],
+            "dashversion":[">2023.1"],
             "class":"stream_annotation"
          }
       ]


### PR DESCRIPTION
Working towards unified dashboard for all versions, this patch removes the conditions from the open source scylla version and older versions