### PR TITLE
types.json: RBNO streaming progress

### DIFF
--- a/grafana/types.json
+++ b/grafana/types.json
@@ -4895,7 +4895,7 @@
             "format":"table"
          },
          {
-            "expr":"(min(scylla_streaming_finished_percentage{cluster=\"$cluster\", dc=~\"$dc\"}*100) by (instance) < 100) or on (instance)  0*sum(scylla_scylladb_current_version{cluster=\"$cluster\", dc=~\"$dc\"}) by (instance)",
+            "expr":"(min(scylla_streaming_finished_percentage{cluster=\"$cluster\", dc=~\"$dc\"}*100) by (instance) < 100) or on (instance) (min(scylla_node_ops_finished_percentage{cluster=\"$cluster\", dc=~\"$dc\"}*100) by (instance) < 100) or on (instance)  0*sum(scylla_scylladb_current_version{cluster=\"$cluster\", dc=~\"$dc\"}) by (instance)",
             "legendFormat":"",
             "interval":"",
             "refId":"G",


### PR DESCRIPTION
This patch makes the node table represent both RBNO and regular stream.

Fixes #2703