### PR TITLE
scylla-detailed: Remove the tablets heatmap

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -174,7 +174,7 @@
                 "panels": [
                     {
                         "class": "collapsible_row_panel",
-                        "collapsed": true,
+                        "collapsed": false,
                         "title": "Tablets information"
                     }
                 ]
@@ -183,24 +183,6 @@
             "class": "row",
             "dashversion":[">2024.2"],
                  "panels": [
-                     {
-                     "title": "Tablets over time per [[by]]",
-                     "class": "heatmap_panel",
-                     "gridPos": {
-                       "h": 13,
-                       "w": 24
-                     },
-                     "targets": [
-                       {
-                         "refId": "A",
-                         "expr": "$topbottom([[filter_limit]], sum(scylla_tablets_count{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by([[by]])) or on() vector(0)",
-                         "range": false,
-                         "format": "time_series",
-                           "instant": false,
-                         "legendFormat": "{{dc}} {{instance}} {{shard}}"
-                       }
-                     ]
-                   },
                      {
                      "title": "Tablets per [[by]]",
                      "class": "barchart_panel",


### PR DESCRIPTION
This patch changes the tablet row; it's now open by default, and the heat map was removed.

<img width="2533" height="370" alt="image" src="https://github.com/user-attachments/assets/d191c99c-24df-4620-8492-b2a5ea41fd3d" />

Fixes #2733