### PR TITLE
.github/workflows/docs-pr.yaml: Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -2,6 +2,9 @@ name: "Docs / Build PR"
 # For more information,
 # see https://sphinx-theme.scylladb.com/stable/deployment/production.html#available-workflows
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylla-monitoring/security/code-scanning/2](https://github.com/scylladb/scylla-monitoring/security/code-scanning/2)

To fix the problem, explicitly declare minimal `GITHUB_TOKEN` permissions for this workflow or for the specific job. Since the job only needs to read the repository to build and test docs, `contents: read` is sufficient. Adding a `permissions` block ensures the workflow doesn’t accidentally get broader write permissions inherited from repo/org defaults.

The best fix without changing functionality is to add a workflow-level `permissions` block right after the `name` (or before `on:`) so it applies to all jobs in this workflow. That block should set `contents: read`. No further permissions are needed for the existing steps (`actions/checkout`, `actions/setup-python`, and `make` commands that run locally). Concretely, in `.github/workflows/docs-pr.yaml`, insert:

```yaml
permissions:
  contents: read
```

near the top of the file. No new methods, imports, or other definitions are required, because this is purely a configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
