### PR TITLE
.github/workflows/docs-pages.yaml: Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -14,6 +14,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylla-monitoring/security/code-scanning/1](https://github.com/scylladb/scylla-monitoring/security/code-scanning/1)

In general, the fix is to explicitly declare GitHub Actions permissions for the `GITHUB_TOKEN` in this workflow, limiting them to only what the docs publishing process requires. This is done by adding a `permissions:` block either at the root (applies to all jobs) or under the specific job (`release:`). Since there is only one job and it’s the one using the token, adding a job-level `permissions` block is the minimal, targeted change.

The best concrete fix here is to add `permissions` under `jobs.release` so that `GITHUB_TOKEN` has `contents: write` and nothing broader. The deploy script is almost certainly pushing built documentation to a branch (such as `gh-pages`) or otherwise updating repository contents, which requires `contents: write`; it does not obviously need other scopes like `issues` or `pull-requests`. Therefore, in `.github/workflows/docs-pages.yaml`, directly under `release:` and at the same indentation level as `runs-on:`, add:

```yaml
    permissions:
      contents: write
```

No imports or new methods are needed; this is purely a YAML configuration change within the GitHub Actions workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
