### PR TITLE
Native histograms GA support

### DIFF
--- a/prometheus-config.sh
+++ b/prometheus-config.sh
@@ -2,6 +2,7 @@
 usage="$(basename "$0") [-h] [-m alert_manager address]  [-L] [-T additional-prometheus-targets] [-G grafana address] [--compose] -- Generate grafana's datasource file"
 CONSUL_ADDRESS=""
 COMPOSE=0
+
 BASE_DIR="$PWD/prometheus/build"
 if [ -f env.sh ]; then
 	. env.sh
@@ -37,6 +38,9 @@ for arg; do
 			;;
         --vector-search)
             VECTOR_SEARCH="1"
+            ;;
+        --native-histogram)
+        	NATIVE_HISTOGRAM="1"
             ;;
 		--no-node-exporter-file)
 			NO_NODE_EXPORTER_FILE="1"
@@ -117,6 +121,10 @@ fi
 
 if [[ "$EVALUATION_INTERVAL" != "" ]]; then
 	sed -i "s/  evaluation_interval: [[:digit:]]*.*/  evaluation_interval: ${EVALUATION_INTERVAL}/g" $BASE_DIR/prometheus.yml
+fi
+
+if [ "$NATIVE_HISTOGRAM" = "1" ]; then
+	sed -i "s/  scrape_native_histograms:.*/  scrape_native_histograms: true/g" $BASE_DIR/prometheus.yml
 fi
 if [[ "$SCRAP_INTERVAL" != "" ]]; then
 	sed -i "s/  scrape_interval: [[:digit:]]*.*# *Default.*/  scrape_interval: ${SCRAP_INTERVAL}s/g" $BASE_DIR/prometheus.yml

--- a/prometheus/prom_rules/prometheus.latency.rules.yml
+++ b/prometheus/prom_rules/prometheus.latency.rules.yml
@@ -298,6 +298,240 @@ groups:
       by: "cluster"
       quantile: "0.99"
       dd: "1"
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency[60s])) by (cluster, dc, instance, scheduling_group_name))
+    labels:
+      by: "instance"
+      quantile: "0.99"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency[60s])) by (cluster, dc, scheduling_group_name))
+    labels:
+      by: "dc"
+      quantile: "0.99"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_write_latency[60s])) by (cluster, scheduling_group_name))
+    labels:
+      by: "cluster"
+      quantile: "0.99"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency[60s])) by (cluster, dc, instance, scheduling_group_name))
+    labels:
+      by: "instance"
+      quantile: "0.99"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency[60s])) by (cluster, dc, scheduling_group_name))
+    labels:
+      by: "dc"
+      quantile: "0.99"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_storage_proxy_coordinator_read_latency[60s])) by (cluster, scheduling_group_name))
+    labels:
+      by: "cluster"
+      quantile: "0.99"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency[60s])) by (cluster, dc, instance, scheduling_group_name))
+    labels:
+      by: "instance"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency[60s])) by (cluster, dc, scheduling_group_name))
+    labels:
+      by: "dc"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_write_latency[60s])) by (cluster, scheduling_group_name))
+    labels:
+      by: "cluster"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency[60s])) by (cluster, dc, instance, scheduling_group_name))
+    labels:
+      by: "instance"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency[60s])) by (cluster, dc, scheduling_group_name))
+    labels:
+      by: "dc"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_read_latency[60s])) by (cluster, scheduling_group_name))
+    labels:
+      by: "cluster"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_write_latency[60s])) by (cluster, dc, instance, scheduling_group_name))
+    labels:
+      by: "instance"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_write_latency[60s])) by (cluster, dc, scheduling_group_name))
+    labels:
+      by: "dc"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_write_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_write_latency[60s])) by (cluster, scheduling_group_name))
+    labels:
+      by: "cluster"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_read_latency[60s])) by (cluster, dc, instance, scheduling_group_name))
+    labels:
+      by: "instance"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_read_latency[60s])) by (cluster, dc, scheduling_group_name))
+    labels:
+      by: "dc"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_read_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_read_latency[60s])) by (cluster, scheduling_group_name))
+    labels:
+      by: "cluster"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_cas_read_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency[60s])) by (cluster, dc, instance, scheduling_group_name))
+    labels:
+      by: "instance"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_cas_read_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency[60s])) by (cluster, dc, scheduling_group_name))
+    labels:
+      by: "dc"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_cas_read_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency[60s])) by (cluster, scheduling_group_name))
+    labels:
+      by: "cluster"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_cas_write_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency[60s])) by (cluster, dc, instance, scheduling_group_name))
+    labels:
+      by: "instance"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_cas_write_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency[60s])) by (cluster, dc, scheduling_group_name))
+    labels:
+      by: "dc"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_cas_write_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency[60s])) by (cluster, scheduling_group_name))
+    labels:
+      by: "cluster"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_cas_read_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency[60s])) by (cluster, dc, instance, scheduling_group_name))
+    labels:
+      by: "instance"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_cas_read_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency[60s])) by (cluster, dc, scheduling_group_name))
+    labels:
+      by: "dc"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_cas_read_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_cas_read_latency[60s])) by (cluster, scheduling_group_name))
+    labels:
+      by: "cluster"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_cas_write_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency[60s])) by (cluster, dc, instance, scheduling_group_name))
+    labels:
+      by: "instance"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_cas_write_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency[60s])) by (cluster, dc, scheduling_group_name))
+    labels:
+      by: "dc"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_storage_proxy_coordinator_cas_write_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_storage_proxy_coordinator_cas_write_latency[60s])) by (cluster, scheduling_group_name))
+    labels:
+      by: "cluster"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_alternator_op_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_alternator_op_latency[60s])>0) by (cluster, dc, instance, op))
+    labels:
+      by: "instance"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_alternator_op_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_alternator_op_latency[60s])>0) by (cluster, dc, op))
+    labels:
+      by: "dc"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_alternator_op_latency_summary
+    expr: histogram_quantile(0.5, sum(rate(scylla_alternator_op_latency[60s])>0) by (cluster, op))
+    labels:
+      by: "cluster"
+      quantile: "0.5"
+      dd: "1"
+  - record: scylla_alternator_op_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_alternator_op_latency[60s])>0) by (cluster, dc, instance, op))
+    labels:
+      by: "instance"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_alternator_op_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_alternator_op_latency[60s])>0) by (cluster, dc, op))
+    labels:
+      by: "dc"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_alternator_op_latency_summary
+    expr: histogram_quantile(0.95, sum(rate(scylla_alternator_op_latency[60s])>0) by (cluster, op))
+    labels:
+      by: "cluster"
+      quantile: "0.95"
+      dd: "1"
+  - record: scylla_alternator_op_latency_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_alternator_op_latency[60s])>0) by (cluster, dc, instance, op))
+    labels:
+      by: "instance"
+      quantile: "0.99"
+      dd: "1"
+  - record: scylla_alternator_op_latency_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_alternator_op_latency[60s])>0) by (cluster, dc, op))
+    labels:
+      by: "dc"
+      quantile: "0.99"
+      dd: "1"
+  - record: scylla_alternator_op_latency_summary
+    expr: histogram_quantile(0.99, sum(rate(scylla_alternator_op_latency[60s])>0) by (cluster, op))
+    labels:
+      by: "cluster"
+      quantile: "0.99"
+      dd: "1"
   - record: vector_store_indexes
     expr: max(count(index_size{job="vector_search"}) by (instance, cluster)) by (cluster)
     labels:

--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -2,6 +2,7 @@ global:
   scrape_interval: 20s # Default Scrape
   scrape_timeout: 15s # Default Scrape timeout
   evaluation_interval: 20s
+  scrape_native_histograms: false
 
   # Attach these labels to any time series or alerts when communicating with
   # external systems (federation, remote storage, Alertmanager).

--- a/start-all.sh
+++ b/start-all.sh
@@ -100,7 +100,8 @@ Options:
   --thanos-sc                    - If set, run thanos sidecar with the Prometheus server.
   --thanos                       - If set, run thanos query as a Grafana datasource.
   --local-thanos                 - If set, run thanos query as a front end to the local thanos sidecar.
-  --enable-protobuf              - If set, enable the experimental Prometheus Protobuf with Native histograms support.
+  --enable-protobuf              - [Deprecated]If set, enable the experimental Prometheus Protobuf with Native histograms support.
+  --native-histogram             - If set, enable the Prometheus Protobuf with Native histograms support.
   --scrap [scrap duration]       - Change the default Prometheus scrap duration. Duration is in seconds.
   --vector-store path/to/file.yml - [depricated] see vector-search
   --vector-search path/to/file.yml- Specifiy a vector search target file, the file should contain a list of vector search servers.
@@ -272,7 +273,10 @@ for arg; do
 			GRAFANA_ENV_ARRAY+=(--disable-anonymous)
 			;;
 		--enable-protobuf)
-			PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY+=(--enable-feature=native-histograms)
+			NATIVE_HISTOGRAM="1"
+			;;
+		--native-histogram)
+			NATIVE_HISTOGRAM="1"
 			;;
 		--alternator)
 			RUN_ALTERNATOR="1"
@@ -785,8 +789,12 @@ for val in "${PROMETHEUS_COMMAND_LINE_OPTIONS_ARRAY[@]}"; do
 		PROMETHEUS_COMMAND_LINE_OPTIONS+=" -$val"
 	fi
 done
-
-./prometheus-config.sh -m $AM_ADDRESS $STACK_CMD $GRAFANA_ADDRESS $SCRAP_CMD $CONSUL_ADDRESS $PROMETHEUS_TARGETS $VECTOR_SEARCH_CMD
+if [ "$NATIVE_HISTOGRAM" = "1" ]; then
+	NATIVE_HISTOGRAM="--native-histogram"
+else
+	NATIVE_HISTOGRAM=""
+fi
+./prometheus-config.sh -m $AM_ADDRESS $STACK_CMD $GRAFANA_ADDRESS $NATIVE_HISTOGRAM $SCRAP_CMD $CONSUL_ADDRESS $PROMETHEUS_TARGETS $VECTOR_SEARCH_CMD
 if [ "$DATA_DIR" != "" ] && [ "$ARCHIVE" != "1" ]; then
 	DATE=$(date +"%Y-%m-%d_%H_%M_%S")
 	if [ -f $DATA_DIR/scylla.txt ]; then


### PR DESCRIPTION
Prometheus 3.8 and higher officially supports native histograms with protobuf.

This series adds multiple changes to accommodate this change.
1. By default, we'll not use native-histograms (we may change this in future releases)
2. A ```--native-histogram``` command line option replaces ```--enable-protobuf``` and update the configuration.
3. The recording rules that create the summaries, for instance, dc, and cluster, can support both histogram variations.
