### PR TITLE
Fix thanos args

### DIFF
--- a/start-thanos-sc.sh
+++ b/start-thanos-sc.sh
@@ -165,7 +165,7 @@ if [ -z "$HOST_NETWORK" ]; then
 fi
 
 echo "Starting Thanos sidecar"
-docker run ${DOCKER_LIMITS["sidecar"]} -d $DOCKER_PARAM $USER_PERMISSIONS \
+docker run ${DOCKER_LIMITS["sidecar"]} -d $USER_PERMISSIONS \
 	$DATA_DIR \
 	$DOCKER_PARAM \
 	-i $PORT_MAPPING --name sidecar$NAME docker.io/thanosio/thanos:$THANOS_VERSION \

--- a/start-thanos.sh
+++ b/start-thanos.sh
@@ -111,7 +111,7 @@ while getopts ':hlp:S:N:D:' option; do
 	S)
 		IFS=','
 		for s in $OPTARG; do
-			SIDECAR+=(--store=$s)
+			SIDECAR+=(--endpoint=$s)
 		done
 		;;
 	D)


### PR DESCRIPTION
This PR removes duplicated `$DOCKER_PARAM`  to fix issue:
```
Starting Thanos sidecar
--restart=unless-stopped --net=monitor-net
docker: network "monitor-net" is specified multiple times

Run 'docker run --help' for more information
```

Also this PR removes deprecated arg `--store`  which was deprecated in thanos 0.38+ 

https://github.com/thanos-io/thanos/releases/tag/v0.38.0

Please note that --endpoint is [temporary solution](https://github.com/thanos-io/thanos/pull/7890#issuecomment-2789628224) until you migrate to preferred way which is configuration file `--endpoint.sd-config(-file)=` 

Please include thanos  functionality to testing procedure before releases.

Fixes #2759