### PR TITLE
scylla-details: Add hints related panels

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -350,6 +350,21 @@
                         "title": "Hints sent $func by [[by]]"
                     },
                     {
+                        "class": "wps_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$topbottom([[filter_limit]], $func(rate(scylla_hints_manager_send_errors{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]]))",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "description": "Number of unexpected errors during sending, sending will be retried later\n\nscylla_hints_manager_send_errors",
+                        "title": "Hints-Send Errors $func by [[by]]"
+                    },
+                    {
                         "class": "rps_panel",
                         "span": 3,
                         "targets": [
@@ -1673,6 +1688,21 @@
             {
                 "class": "row",
                 "panels": [
+                	{
+                        "class": "writes_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$topbottom([[filter_limit]], $func(scylla_hints_for_views_manager_written{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]]))",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Hints written for view $func by [[by]]",
+                        "description" : "Number of successfully written hints.\n\nscylla_hints_for_views_manager_written"
+                    },
                     {
                         "class": "wps_panel",
                         "span": 3,
@@ -1696,6 +1726,21 @@
                         ],
                         "title": "Hints for view $func by [[by]]",
                         "description" : "Number of hints sent for view."
+                    },
+                    {
+                        "class": "writes_panel",
+                        "span": 3,
+                        "targets": [
+                            {
+                                "expr": "$topbottom([[filter_limit]], $func(scylla_hints_for_views_manager_send_errors{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}) by ([[by]]))",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "refId": "A",
+                                "step": 10
+                            }
+                        ],
+                        "title": "Hints-Send Errors for view $func by [[by]]",
+                        "description" : "Number of unexpected errors during sending, sending will be retried later.\n\nscylla_hints_for_views_manager_send_errors"
                     },
                     {
                         "class": "writes_panel",


### PR DESCRIPTION
This patch adds the scylla_hints_manager_send_errors to the hints section and scylla_hints_for_views_manager_written, and scylla_hints_for_views_manager_send_errors to the hints for view section.
<img width="1923" height="264" alt="image" src="https://github.com/user-attachments/assets/3590dbef-e314-468d-961f-1311fbbe657a" />

<img width="1907" height="260" alt="image" src="https://github.com/user-attachments/assets/a9b09d22-99dc-48de-9d71-ff1b5feec4da" />

Fixes #2768