### PR TITLE
packer: fix GCP Ubuntu image family name

### DIFF
--- a/packer/scylla-monitor-template.json
+++ b/packer/scylla-monitor-template.json
@@ -143,7 +143,7 @@
 
     "gcp_project_id": "scylla-images",
     "gcp_zone": "europe-west1-b",
-    "gcp_source_image_family": "ubuntu-minimal-2404-lts",
+    "gcp_source_image_family": "ubuntu-minimal-2404-lts-amd64",
     "gcp_image_storage_location": "europe-west1",
     "gcp_instance_type": "n1-standard-1",
     "gcp_ssh_username": "ubuntu",


### PR DESCRIPTION
The image family 'ubuntu-minimal-2404-lts' does not exist in GCP. Changed to 'ubuntu-minimal-2404-lts-amd64' which is the correct image family name for Ubuntu 24.04 LTS minimal in ubuntu-os-cloud.

Fixes: https://scylladb.atlassian.net/browse/RELENG-250