### PR TITLE
vector-search: seperate the version row from the repeated index rows

### DIFF
--- a/grafana/scylla-vector-search.template.json
+++ b/grafana/scylla-vector-search.template.json
@@ -464,6 +464,23 @@
                 "title": "Index Row"
             },
             {
+                "class": "row",
+                "panels": [
+                    {
+                      "collapsed": false,
+                      "datasource": null,
+                      "id": "auto",
+                      "gridPos": {
+                        "h": 1,
+                        "w": 24
+                      },
+                      "panels": [],
+                      "title": "",
+                      "type": "row"
+                    }
+                ]
+            },
+            {
                 "class": "monitoring_version_row"
             }
         ],


### PR DESCRIPTION
Fixes #2792