### PR TITLE
scylla-os: limit the nodes list to node_exporter.*

### DIFF
--- a/grafana/scylla-os.template.json
+++ b/grafana/scylla-os.template.json
@@ -709,7 +709,7 @@
                       },
                       "includeAll":true,
                       "multi":true,
-                    "query": "label_values(node_filesystem_avail_bytes{cluster=\"$cluster\", dc=~\"$dc\"}, instance)"
+                    "query": "label_values(node_filesystem_avail_bytes{cluster=\"$cluster\", dc=~\"$dc\", job=~\"node_exporter.*\"}, instance)"
                 },
                 {
                     "allValue": null,


### PR DESCRIPTION
This patch makes the nodes list in the os dashboard more robust to additional targets.
Only job names that start with node_exporrter.* will be included. 

Fixes #2806