### PR TITLE
collect small subset of metrics from Grafana

### DIFF
--- a/prometheus/prometheus.yml.template
+++ b/prometheus/prometheus.yml.template
@@ -250,3 +250,7 @@ scrape_configs:
   static_configs:
     - targets:
       - GRAFANA_ADDRESS
+  metric_relabel_configs:
+    - source_labels: [__name__]
+      regex: 'grafana_process_resident_memory_bytes|grafana_http_request_duration_seconds_bucket|grafana_data_source_requests_errors_total'
+      action: keep


### PR DESCRIPTION
This pr removes most of grafana's collected metrics.
After this patch only 
```
grafana_process_resident_memory_bytes
grafana_http_request_duration_seconds_bucket
grafana_data_source_requests_errors_total
```
Will be collected

Fixes #2805