### PR TITLE
PM-269: Add the sync Jira-GH github action to scylla-monitoring.git

### DIFF
--- a/.github/workflows/call_jira_sync.yml
+++ b/.github/workflows/call_jira_sync.yml
@@ -1,0 +1,18 @@
+name: Sync Jira Based on PR Events
+
+on:
+  pull_request_target:
+    types: [opened, edited, ready_for_review, review_requested, labeled, unlabeled, closed]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  jira-sync:
+    uses: scylladb/github-automation/.github/workflows/main_pr_events_jira_sync.yml@main
+    with:
+      caller_action: ${{ github.event.action }}
+    secrets:
+      caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}


### PR DESCRIPTION
## What changed
- Added `call_jira_sync.yml` to `.github/workflows/` to enable automatic Jira sync for PR events.

## Why (Requirements Summary)
- This workflow triggers the reusable `main_pr_events_jira_sync.yml` from `scylladb/github-automation` on PR events (opened, edited, labeled, unlabeled, closed, ready_for_review, review_requested).
- It automatically extracts Jira keys from PR titles/bodies and syncs labels, status transitions, and comments to Jira.


Fixes:PM-269