### PR TITLE
PM-270: Add Jira-GH sync when adding/removing a milestone in a PR

### DIFF
--- a/.github/workflows/call_jira_sync_pr_milestone.yml
+++ b/.github/workflows/call_jira_sync_pr_milestone.yml
@@ -1,0 +1,22 @@
+name: Sync Jira Based on PR Milestone Events
+
+on:
+  pull_request_target:
+    types: [milestoned, demilestoned]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  jira-sync-milestone-set:
+    if: github.event.action == 'milestoned'
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_milestone_set.yml@main
+    secrets:
+      caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
+
+  jira-sync-milestone-removed:
+    if: github.event.action == 'demilestoned'
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_milestone_removed.yml@main
+    secrets:
+      caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}


### PR DESCRIPTION
## What changed
- Added `call_jira_sync_pr_milestone.yml` to `.github/workflows/`.

## Why (Requirements Summary)
- This workflow listens for `milestoned` and `demilestoned` PR events and calls the reusable workflows from `scylladb/github-automation` to set or remove the corresponding Fix Version on the linked Jira issue.
- The same workflow is already deployed in `scylladb/scylladb` and other repos.

Fixes:PM-270