### PR TITLE
PM-271: Create/close a new Jira release when a milestone is created/closed in GH

### DIFF
--- a/.github/workflows/call_sync_milestone_to_jira.yml
+++ b/.github/workflows/call_sync_milestone_to_jira.yml
@@ -1,0 +1,14 @@
+name: Call Jira release creation for new milestone
+
+on:
+  milestone:
+    types: [created, closed]
+
+jobs:
+  sync-milestone-to-jira:
+    uses: scylladb/github-automation/.github/workflows/main_sync_milestone_to_jira_release.yml@main
+    with:
+      # Comma-separated list of Jira project keys
+      jira_project_keys: "MONITOR"
+    secrets:
+      caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}


### PR DESCRIPTION
## What changed
- Added `call_sync_milestone_to_jira.yml` to `.github/workflows/`.

## Why (Requirements Summary)
- When a new milestone is created or closed in this repo, the workflow calls the reusable `main_sync_milestone_to_jira_release.yml` from `scylladb/github-automation` to create or close the corresponding release in the `MONITOR` Jira project.
- This is the same workflow pattern used in scylladb.git (with project keys adjusted to `MONITOR` only).

## How tested
- The same reusable workflow is already in production in scylladb.git and other repos. Only the `jira_project_keys` parameter differs.

Fixes:PM-271