### PR TITLE
PM-272: Duplicate new GitHub issues to Jira MONITOR project

### DIFF
--- a/.github/workflows/call_sync_gh_issue_to_jira.yml
+++ b/.github/workflows/call_sync_gh_issue_to_jira.yml
@@ -1,0 +1,17 @@
+name: Sync new GitHub issues to Jira
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sync-issue-to-jira:
+    uses: scylladb/github-automation/.github/workflows/main_sync_gh_issue_to_jira.yml@main
+    with:
+      jira_project_key: "MONITOR"
+    secrets:
+      caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}


### PR DESCRIPTION
## What changed
- Added `call_sync_gh_issue_to_jira.yml` to `.github/workflows/`.

## Why (Requirements Summary)
- When a new GitHub issue is opened in scylla-monitoring, it should be automatically duplicated as a Jira issue in the MONITOR project.
- The caller workflow triggers `main_sync_gh_issue_to_jira.yml` from `scylladb/github-automation` on `issues.opened` events.
- The reusable workflow runs `sync_gh_issue_to_jira.py` which:
  - Maps GH issue type/labels to Jira issue types (Bug, Enhancement, Epic, Task fallback)
  - Syncs labels, priority (P0-P4), and milestone (fixVersion)
  - Looks up assignee and reporter by display name in Jira (best-effort)
  - Adds a clickable link to the original GH issue in the Jira description footer
  - Appends a clickable link to the new Jira issue in the GH issue body footer

## How tested
- The reusable workflow and script are added in github-automation PR #164.
- Will be integration-tested once both PRs are merged.

## Dependencies
- Requires github-automation PR #164 to be merged first.

Fixes:PM-272