### PR TITLE
PM-272: Rename issue sync caller workflow

### DIFF
--- a/.github/workflows/call_create_jira_issue_from_gh_issue.yml
+++ b/.github/workflows/call_create_jira_issue_from_gh_issue.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   sync-issue-to-jira:
-    uses: scylladb/github-automation/.github/workflows/main_sync_gh_issue_to_jira.yml@main
+    uses: scylladb/github-automation/.github/workflows/main_create_jira_issue_from_gh_issue.yml@main
     with:
       jira_project_key: "MONITOR"
     secrets:


### PR DESCRIPTION
## What changed
- Renamed `call_sync_gh_issue_to_jira.yml` to `call_create_jira_issue_from_gh_issue.yml`
- Updated `uses:` reference to `main_create_jira_issue_from_gh_issue.yml`

## Why (Requirements Summary)
- Aligns caller workflow filename with the renamed reusable workflow in github-automation

Refs:PM-272