### PR TITLE
scylla-cql: Fix doc reference

### DIFF
--- a/grafana/scylla-cql.template.json
+++ b/grafana/scylla-cql.template.json
@@ -271,7 +271,7 @@
                     {
                         "class": "text_panel",
                         "options": {
-                            "content": "<span style=\"color:#5780C1;font-size: 2rem;\">CQL System tables</span></br><span style=\"\">The following information is based on Scylla Plugin configuration, check the </span><a target=\"_blank\" herf=\"https://monitoring.docs.scylladb.com/stable/install/monitor-without-docker.html#using-scylla-plugin-with-grafana\" onclick=\"window.open('https://monitoring.docs.scylladb.com/stable/install/monitor-without-docker.html#using-scylla-plugin-with-grafana', '_blank')\">documentation</a><span> for more details on how to enable it.</span>",
+                            "content": "<span style=\"color:#5780C1;font-size: 2rem;\">CQL System tables</span></br><span style=\"\">The following information is based on Scylla Plugin configuration, check the </span><a href=\"https://monitoring.docs.scylladb.com/stable/install/monitor-without-docker.html#using-scylla-plugin-with-grafana\"  target=\"_blank\"  rel=\"noopener noreferrer\"> documentation </a><span> for more details on how to enable it.</span>",
                             "mode": "html"
                         },
                         "style": {}


### PR DESCRIPTION
Fixes a bug in the <a> ref to documentation.
Fixes #2820