### PR TITLE
prometheus-config.sh: Add a ks_index label to vector store metrics

### DIFF
--- a/prometheus-config.sh
+++ b/prometheus-config.sh
@@ -169,6 +169,9 @@ if [ ! -z "$VECTOR_SEARCH" ]; then
       action: replace
       target_label: instance
       replacement: '\${1}'
+    - source_labels: [keyspace, index_name]
+      separator: ','
+      target_label: ks_index
 - job_name: vector_search_os
   honor_labels: false
   file_sd_configs:


### PR DESCRIPTION
This patch adds a required label for vector search metrics. The label is a combination of the keyspace and the index name to create a unique name across keyspaces.
relates to #2827 