### PR TITLE
scylla-os: Add network dropped packets graphs

### DIFF
--- a/grafana/scylla-os.template.json
+++ b/grafana/scylla-os.template.json
@@ -355,14 +355,6 @@
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1
-                            },
-                            {
-                                "expr": "sum(rate(node_network_receive_packets{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", device=\"$monitor_network_interface\", job=~\"node_exporter.*\"}[4m])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "B",
-                                "step": 1
                             }
                         ],
                         "title": "Interface Rx Packets"
@@ -377,14 +369,6 @@
                                 "legendFormat": "",
                                 "metric": "",
                                 "refId": "A",
-                                "step": 1
-                            },
-                            {
-                                "expr": "sum(rate(node_network_transmit_packets{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", device=\"$monitor_network_interface\", job=~\"node_exporter.*\"}[4m])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "B",
                                 "step": 1
                             }
                         ],
@@ -407,14 +391,6 @@
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1
-                            },
-                            {
-                                "expr": "sum(8*rate(node_network_receive_bytes{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", device=\"$monitor_network_interface\", job=~\"node_exporter.*\"}[4m])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "B",
-                                "step": 1
                             }
                         ],
                         "title": "Interface Rx bps"
@@ -430,17 +406,45 @@
                                 "metric": "",
                                 "refId": "A",
                                 "step": 1
-                            },
-                            {
-                                "expr": "sum(8*rate(node_network_transmit_bytes{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", device=\"$monitor_network_interface\", job=~\"node_exporter.*\"}[4m])) by ([[by]])",
-                                "intervalFactor": 1,
-                                "legendFormat": "",
-                                "metric": "",
-                                "refId": "B",
-                                "step": 1
                             }
                         ],
                         "title": "Interface Tx bps"
+                    }
+                ],
+                "title": "New row"
+            },
+            {
+                "class": "row",
+                "panels": [
+                    {
+                        "class": "pps_panel",
+                        "span": 6,
+                        "targets": [
+                            {
+                                "expr": "sum(rate(node_network_receive_drop_total{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", device=\"$monitor_network_interface\", job=~\"node_exporter.*\"}[4m])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Interface Received Dropped Packets"
+                    },
+                    {
+                        "class": "pps_panel",
+                        "span": 6,
+                        "targets": [
+                            {
+                                "expr": "sum(rate(node_network_transmit_drop_total{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", device=\"$monitor_network_interface\", job=~\"node_exporter.*\"}[4m])) by ([[by]])",
+                                "intervalFactor": 1,
+                                "legendFormat": "",
+                                "metric": "",
+                                "refId": "A",
+                                "step": 1
+                            }
+                        ],
+                        "title": "Interface Transmit Dropped Packets"
                     }
                 ],
                 "title": "New row"


### PR DESCRIPTION
This patch addresses two issues with the network graph:
1. It removes the old network graph name (as it's a very old node_exporter)
2. It adds two panels for send and receive dropped packets.

Fixes #2655