### PR TITLE
Update Os dashboard look

### DIFF
--- a/grafana/scylla-os.template.json
+++ b/grafana/scylla-os.template.json
@@ -3,37 +3,33 @@
         "class": "dashboard",
         "overwrite": true,
         "rows": [
-            {
+             {
                 "class": "row",
                 "panels": [
                     {
-                        "class": "collapsible_row_panel",
-                        "title": ""
+                      "collapsed": false,
+                      "datasource": null,
+                      "id": "auto",
+                      "gridPos": {
+                        "h": 1,
+                        "w": 24
+                      },
+                      "panels": [],
+                      "title": "Cluster OS Information $cluster $account_name $cluster_name ",
+                      "type": "row"
                     }
                 ]
             },
             {
-                "class": "logo_row"
-            },
-            {
                 "class": "row",
-                "panels": [
-                    {
-                        "class": "collapsible_row_panel",
-                        "title": ""
-                    }
-                ]
-            },
-            {
-                "class": "row",
-                "height": "200px",
                 "panels": [
                     {
                         "class": "piechart_panel_percent",
                         "height": "250px",
-                        "repeat": "node",
-                        "maxPerRow": 8,
-                        "repeatDirection": "h",
+                        "gridPos": {
+                            "h": 6,
+                            "w": 5
+                        },
                         "targets": [
                             {
                                 "expr": "sum(node_filesystem_avail_bytes{mountpoint=~\"$mount_point\", instance=~\"$node\", job=~\"node_exporter.*\"})",
@@ -55,9 +51,14 @@
                             }
                         ],
                         "title": "Total Storage $node"
+                    },
+                    {
+                        "class": "device_table"
+                    },
+                    {
+                        "class": "low_disk_partitions_table"
                     }
-                ],
-                "title": "New row"
+                ]
             },
             {
                 "class": "row",
@@ -800,6 +801,28 @@
                     "tagsQuery": "",
                     "type": "query",
                     "useTags": false
+                },
+                {
+                    "class": "template_variable_single",
+                    "definition": "label_values(scylla_scylladb_current_version,cluster_name)",
+                    "query": {
+                      "qryType": 1,
+                      "query": "label_values(scylla_scylladb_current_version,cluster_name)"
+                    },
+                    "hide": 2,
+                    "label": "cluster_name",
+                    "name": "cluster_name"
+                },
+                {
+                    "class": "template_variable_single",
+                    "definition": "label_values(scylla_scylladb_current_version,account_name)",
+                    "query": {
+                      "qryType": 1,
+                      "query": "label_values(scylla_scylladb_current_version,account_name)"
+                    },
+                    "hide": 2,
+                    "label": "account_name",
+                    "name": "account_name"
                 },
                 {
                     "class": "template_variable_custom",

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -2063,7 +2063,7 @@
                 "value": [
                   {
                     "title": "",
-                    "url": "/d/${__data.fields.dashboard}-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&from=${__from}&to=${__to}"
+                    "url": "/d/${__data.fields.dashboard}-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&${__url_time_range}"
                   }
                 ]
               },
@@ -2468,7 +2468,7 @@
             "decimals":2,
             "link":true,
             "linkTooltip":"Jump to the detailed node information",
-            "linkUrl":"./d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell}&from=${__from}&to=${__to}",
+            "linkUrl":"./d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell}&${__url_time_range}",
             "mappingType":1,
             "pattern":"instance",
             "thresholds":[],
@@ -2511,7 +2511,7 @@
             "decimals":2,
             "link":true,
             "linkTooltip":"${__cell_11}",
-            "linkUrl":"./d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}&from=${__from}&to=${__to}",
+            "linkUrl":"./d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}&${__url_time_range}",
             "mappingType":1,
             "pattern":"svr",
             "thresholds":[],
@@ -2530,7 +2530,7 @@
             "decimals":2,
             "link":true,
             "linkTooltip":"Jump to the OS node information",
-            "linkUrl":"./d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}&from=${__from}&to=${__to}",
+            "linkUrl":"./d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}&${__url_time_range}",
             "mappingType":1,
             "pattern":"OS",
             "thresholds":[],
@@ -2554,7 +2554,7 @@
             "decimals":2,
             "link":true,
             "linkTooltip":"Jump to the CQL information",
-            "linkUrl":"./d/cql-[[dash_version]]/scylla-cql?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}&from=${__from}&to=${__to}",
+            "linkUrl":"./d/cql-[[dash_version]]/scylla-cql?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}&${__url_time_range}",
             "mappingType":1,
             "pattern":"CQL",
             "thresholds":[],
@@ -2811,7 +2811,7 @@
                            "value": [
                            {
                               "title": "",
-                              "url": "/d/${__dashboard.uid}/${__dashboard.slug}?from=${__from}&to=${__to}&var-cluster=${cluster}&var-dc=${dc}&var-node=${node}&var-shard=${shard}&var-func=${func}&var-table=${__value.text}&var-ks=${ks}"
+                              "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__url_time_range}&var-cluster=${cluster}&var-dc=${dc}&var-node=${node}&var-shard=${shard}&var-func=${func}&var-table=${__value.text}&var-ks=${ks}"
                            }
                            ]
                         }
@@ -3157,7 +3157,7 @@
                            "value": [
                            {
                               "title": "",
-                              "url": "/d/${__dashboard.uid}/${__dashboard.slug}?from=${__from}&to=${__to}&var-cluster=${cluster}&var-dc=${dc}&var-node=${node}&var-shard=${shard}&var-func=${func}&var-ks=${__value.text}"
+                              "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__url_time_range}&var-cluster=${cluster}&var-dc=${dc}&var-node=${node}&var-shard=${shard}&var-func=${func}&var-ks=${__value.text}"
                            }
                            ]
                         }
@@ -3489,7 +3489,7 @@
                     "value": [
                       {
                         "title": "Group",
-                        "url": "/d/${__dashboard.uid}/${__dashboard.slug}?from=${__from}&to=${__to}&var-cluster=${cluster}&var-dc=${dc}&var-node=${node}&var-shard=${shard}&var-func=${func}&var-sg=${__value.text}"
+                        "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__url_time_range}&var-cluster=${cluster}&var-dc=${dc}&var-node=${node}&var-shard=${shard}&var-func=${func}&var-sg=${__value.text}"
                       }
                     ]
                   }
@@ -3941,7 +3941,7 @@
                      "value":[
                         {
                            "title":"OS Information Dashboard, an Error indicates there are OS related errors",
-                           "url":"/d/OS-[[dash_version]]/os-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&from=${__from}&to=${__to}"
+                           "url":"/d/OS-[[dash_version]]/os-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&${__url_time_range}"
                         }
                      ]
                   },
@@ -4015,7 +4015,7 @@
                      "value":[
                         {
                            "title":"Cordinator and Replica node errors",
-                           "url":"/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&from=${__from}&to=${__to}"
+                           "url":"/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&${__url_time_range}"
                         }
                      ]
                   },
@@ -4089,7 +4089,7 @@
                      "value":[
                         {
                            "title":"Detailed view",
-                           "url":"/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&from=${__from}&to=${__to}"
+                           "url":"/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&${__url_time_range}"
                         }
                      ]
                   }
@@ -4540,7 +4540,7 @@
                 "value": [
                   {
                     "title": "DC",
-                    "url": "/d/${__dashboard.uid}/${__dashboard.slug}?from=${__from}&to=${__to}&var-cluster=${cluster}&var-dc=${__value.text}&var-node=${node}&var-shard=${shard}&var-func=${func}&var-sg=${sg}"
+                    "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__url_time_range}&var-cluster=${cluster}&var-dc=${__value.text}&var-node=${node}&var-shard=${shard}&var-func=${func}&var-sg=${sg}"
                   }
                 ]
               }
@@ -4829,7 +4829,7 @@
                      "value":[
                         {
                            "title":"Detailed view",
-                           "url":"/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&from=${__from}&to=${__to}"
+                           "url":"/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&${__url_time_range}"
                         }
                      ]
                   }
@@ -4967,7 +4967,7 @@
                      "value":[
                         {
                            "title":"OS Information Dashboard, an Error indicates there are OS related errors",
-                           "url":"/d/OS-[[dash_version]]/os-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&from=${__from}&to=${__to}"
+                           "url":"/d/OS-[[dash_version]]/os-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&${__url_time_range}"
                         }
                      ]
                   },
@@ -5041,7 +5041,7 @@
                      "value":[
                         {
                            "title":"Cordinator and Replica node errors",
-                           "url":"/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&from=${__from}&to=${__to}"
+                           "url":"/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&${__url_time_range}"
                         }
                      ]
                   },

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -4656,6 +4656,339 @@
         }
       }
     },
+    "low_disk_partitions_table": {
+      "type": "table",
+      "title": "Low-Space Partitions",
+      "description": "Partitions with low free space",
+      "gridPos": {
+         "h": 6,
+         "w": 5
+      },
+      "fieldConfig": {
+         "defaults": {
+            "custom": {
+            "align": "auto",
+            "footer": {
+               "reducers": []
+            },
+            "cellOptions": {
+               "type": "auto"
+            },
+            "inspect": false,
+            "minWidth": 100,
+            "filterable": true
+            },
+            "mappings": [],
+            "thresholds": {
+            "mode": "absolute",
+            "steps": [
+               {
+                  "value": null,
+                  "color": "green"
+               },
+               {
+                  "value": 80,
+                  "color": "red"
+               }
+            ]
+            },
+            "color": {
+            "mode": "thresholds"
+            },
+            "unit": "percentunit"
+         },
+         "overrides": [
+            {
+            "matcher": {
+               "id": "byName",
+               "options": "Value"
+            },
+            "properties": [
+               {
+                  "id": "custom.width",
+                  "value": 100
+               },
+               {
+                  "id": "displayName",
+                  "value": "% Free"
+               }
+            ]
+            },
+            {
+            "matcher": {
+               "id": "byName",
+               "options": "dc"
+            },
+            "properties": [
+               {
+                  "id": "custom.width",
+                  "value": 140
+               }
+            ]
+            },
+            {
+            "matcher": {
+               "id": "byName",
+               "options": "instance"
+            },
+            "properties": [
+               {
+                  "id": "links",
+                  "value": [
+                  {
+                     "title": "Instance information",
+                     "url": "/d/${__dashboard.uid}/${__dashboard.slug}?orgId=1&var-by=instance&var-node=${__data.fields[0]}&${__url_time_range}"
+                  }
+                  ]
+               }
+            ]
+            },
+            {
+            "matcher": {
+               "id": "byName",
+               "options": "mountpoint"
+            },
+            "properties": [
+               {
+                  "id": "links",
+                  "value": [
+                  {
+                     "title": "Show mount point",
+                     "url": "./d/${__dashboard.uid}/${__dashboard.slug}?orgId=1&var-by=instance&var-node=${__data.fields[0]}&${__url_time_range}&var-mount_point=${__data.fields[1]}"
+                  },
+                  {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "% Free"
+                     }
+                  ]
+                  }
+                  ]
+               }
+            ]
+            }
+         ]
+      },
+      "transformations": [
+         {
+            "id": "filterFieldsByName",
+            "options": {
+            "include": {
+               "names": [
+                  "instance",
+                  "mountpoint",
+                  "Value"
+               ]
+            }
+            }
+         }
+      ],
+      "targets": [
+         {
+            "refId": "A",
+            "editorMode": "code",
+            "expr": "bottomk(20, node_filesystem_avail_bytes{job=~\"node_exporter.*\", mountpoint=~\"$mount_point\", instance=~\"$node\"}/node_filesystem_size_bytes{job=~\"node_exporter.*\", mountpoint=~\"$mount_point\", instance=~\"$node\"}<0.11)",
+            "legendFormat": "__auto",
+            "range": false,
+            "format": "table",
+            "instant": true,
+            "exemplar": false
+         }
+      ],
+      "datasource": "prometheus",
+      "options": {
+         "showHeader": true,
+         "cellHeight": "sm"
+      }
+   },
+    "device_table": {
+      "datasource":  "prometheus",
+      "title": "Disk And Partition Information",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "links": [
+            {
+               "title": "Device information",
+               "url": "/d/${__dashboard.uid}/${__dashboard.slug}?orgId=1&var-by=instance&var-node=${__data.fields[0]}&var-monitor_disk=${__data.fields[1]}&${__url_time_range}"
+            }
+         ],
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #A"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "decbytes"
+              },
+              {
+                "id": "displayName",
+                "value": "Free Space"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #B"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "% Used"
+              },
+              {
+                "id": "unit",
+                "value": "percentunit"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #C"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "decbytes"
+              },
+              {
+                "id": "displayName",
+                "value": "Used"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 19
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "label_join(label_replace(node_filesystem_avail_bytes{mountpoint=~\"$mount_point\", instance=~\"$node\", device=~\".*$monitor_disk\", job=~\"node_exporter.*\"}, \"device\", \"$1\", \"device\", \"/dev/(.*)\") * on(instance, device) group_left(model) node_disk_info , \"instance_device\", \":\", \"instance\", \"mountpoint\")",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "1- (label_join(label_replace(node_filesystem_avail_bytes{mountpoint=~\"$mount_point\", instance=~\"$node\", device=~\".*$monitor_disk\", job=~\"node_exporter.*\"}/node_filesystem_size_bytes{mountpoint=~\"$mount_point\", instance=~\"$node\", device=~\".*$monitor_disk\", job=~\"node_exporter.*\"}, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance_device\", \":\", \"instance\", \"mountpoint\"))",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "(label_join(label_replace(node_filesystem_size_bytes{mountpoint=~\"$mount_point\", instance=~\"$node\", device=~\".*$monitor_disk\", job=~\"node_exporter.*\"}-node_filesystem_avail_bytes{mountpoint=~\"$mount_point\", instance=~\"$node\", device=~\".*$monitor_disk\", job=~\"node_exporter.*\"}, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance_device\", \":\", \"instance\", \"mountpoint\"))",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "C"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "instance_device",
+            "mode": "outerTabular"
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "device 1",
+                "instance 1",
+                "model",
+                "fstype 1",
+                "Value #A",
+                "Value #B",
+                "Value #C",
+                "mountpoint 1"
+              ]
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {
+              "instance 1": 0,
+              "device 1": 1,
+              "fstype 1": 2,
+              "mountpoint 1": 3,
+              "model": 4,
+              "Value #A": 5,
+              "Value #B": 6,
+              "Value #C": 7
+            },
+            "renameByName": {
+              "Value #D": ""
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
    "small_nodes_table":{
       "datasource":"prometheus",
       "id":"auto",

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -2063,7 +2063,7 @@
                 "value": [
                   {
                     "title": "",
-                    "url": "/d/${__data.fields.dashboard}-[[dash_version]]?refresh=30s&orgId=1&var-by=instance&${__url_time_range}"
+                    "url": "/d/${__data.fields.dashboard}-[[dash_version]]?orgId=1&var-by=instance&${__url_time_range}"
                   }
                 ]
               },
@@ -2468,7 +2468,7 @@
             "decimals":2,
             "link":true,
             "linkTooltip":"Jump to the detailed node information",
-            "linkUrl":"./d/detailed-[[dash_version]]/Detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__cell}&${__url_time_range}",
+            "linkUrl":"./d/detailed-[[dash_version]]/Detailed?orgId=1&var-by=instance&var-node=${__cell}&${__url_time_range}",
             "mappingType":1,
             "pattern":"instance",
             "thresholds":[],
@@ -2511,7 +2511,7 @@
             "decimals":2,
             "link":true,
             "linkTooltip":"${__cell_11}",
-            "linkUrl":"./d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}&${__url_time_range}",
+            "linkUrl":"./d/OS-[[dash_version]]/OS-metrics?orgId=1&var-by=instance&var-node=${__cell_8}&${__url_time_range}",
             "mappingType":1,
             "pattern":"svr",
             "thresholds":[],
@@ -2530,7 +2530,7 @@
             "decimals":2,
             "link":true,
             "linkTooltip":"Jump to the OS node information",
-            "linkUrl":"./d/OS-[[dash_version]]/OS-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}&${__url_time_range}",
+            "linkUrl":"./d/OS-[[dash_version]]/OS-metrics?orgId=1&var-by=instance&var-node=${__cell_8}&${__url_time_range}",
             "mappingType":1,
             "pattern":"OS",
             "thresholds":[],
@@ -2554,7 +2554,7 @@
             "decimals":2,
             "link":true,
             "linkTooltip":"Jump to the CQL information",
-            "linkUrl":"./d/cql-[[dash_version]]/scylla-cql?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}&${__url_time_range}",
+            "linkUrl":"./d/cql-[[dash_version]]/scylla-cql?orgId=1&var-by=instance&var-node=${__cell_8}&${__url_time_range}",
             "mappingType":1,
             "pattern":"CQL",
             "thresholds":[],
@@ -2578,7 +2578,7 @@
             "decimals":2,
             "link":true,
             "linkTooltip":"Jump to the Errors metrics information",
-            "linkUrl":"./d/error-[[dash_version]]/scylla-errors?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+            "linkUrl":"./d/error-[[dash_version]]/scylla-errors?orgId=1&var-by=instance&var-node=${__cell_8}",
             "mappingType":1,
             "pattern":"Errors",
             "thresholds":[],
@@ -2602,7 +2602,7 @@
             "decimals":2,
             "link":true,
             "linkTooltip":"Jump to the Errors metrics information",
-            "linkUrl":"./d/io-[[dash_version]]/i-o?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+            "linkUrl":"./d/io-[[dash_version]]/i-o?orgId=1&var-by=instance&var-node=${__cell_8}",
             "mappingType":1,
             "pattern":"IO",
             "thresholds":[],
@@ -2627,7 +2627,7 @@
             "decimals":2,
             "link":true,
             "linkTooltip":"Jump to the node CPU information",
-            "linkUrl":"./d/cpu-[[dash_version]]/CPU-Metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__cell_8}",
+            "linkUrl":"./d/cpu-[[dash_version]]/CPU-Metrics?orgId=1&var-by=instance&var-node=${__cell_8}",
             "mappingType":1,
             "pattern":"CPU",
             "thresholds":[],
@@ -3941,7 +3941,7 @@
                      "value":[
                         {
                            "title":"OS Information Dashboard, an Error indicates there are OS related errors",
-                           "url":"/d/OS-[[dash_version]]/os-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&${__url_time_range}"
+                           "url":"/d/OS-[[dash_version]]/os-metrics?orgId=1&var-by=instance&var-node=${__data.fields[0]}&${__url_time_range}"
                         }
                      ]
                   },
@@ -4015,7 +4015,7 @@
                      "value":[
                         {
                            "title":"Cordinator and Replica node errors",
-                           "url":"/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&${__url_time_range}"
+                           "url":"/d/detailed-[[dash_version]]/detailed?orgId=1&var-by=instance&var-node=${__data.fields[0]}&${__url_time_range}"
                         }
                      ]
                   },
@@ -4089,7 +4089,7 @@
                      "value":[
                         {
                            "title":"Detailed view",
-                           "url":"/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&${__url_time_range}"
+                           "url":"/d/detailed-[[dash_version]]/detailed?orgId=1&var-by=instance&var-node=${__data.fields[0]}&${__url_time_range}"
                         }
                      ]
                   }
@@ -4829,7 +4829,7 @@
                      "value":[
                         {
                            "title":"Detailed view",
-                           "url":"/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&${__url_time_range}"
+                           "url":"/d/detailed-[[dash_version]]/detailed?orgId=1&var-by=instance&var-node=${__data.fields[0]}&${__url_time_range}"
                         }
                      ]
                   }
@@ -4967,7 +4967,7 @@
                      "value":[
                         {
                            "title":"OS Information Dashboard, an Error indicates there are OS related errors",
-                           "url":"/d/OS-[[dash_version]]/os-metrics?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&${__url_time_range}"
+                           "url":"/d/OS-[[dash_version]]/os-metrics?orgId=1&var-by=instance&var-node=${__data.fields[0]}&${__url_time_range}"
                         }
                      ]
                   },
@@ -5041,7 +5041,7 @@
                      "value":[
                         {
                            "title":"Cordinator and Replica node errors",
-                           "url":"/d/detailed-[[dash_version]]/detailed?refresh=30s&orgId=1&var-by=instance&var-node=${__data.fields[0]}&${__url_time_range}"
+                           "url":"/d/detailed-[[dash_version]]/detailed?orgId=1&var-by=instance&var-node=${__data.fields[0]}&${__url_time_range}"
                         }
                      ]
                   },


### PR DESCRIPTION
This series updates the OS dashboard.

The main motivation is to replace the row of pie chart disk panels with a table.
The logo row was replaced with the cluster information row.
The repeated disk pie chart panels are removed. They are replaced with
one table for all devices and mount points. A table with just a problematic
mount point.
And one Pie chart that combines all the current filtered mount points.


<img width="1900" height="417" alt="os-dashboard" src="https://github.com/user-attachments/assets/80117935-bb30-43ed-8a9b-bddd2ad29745" />

Fixes #2834
