### PR TITLE
Add table of tables to alternator

### DIFF
--- a/grafana/alternator.template.json
+++ b/grafana/alternator.template.json
@@ -29,8 +29,14 @@
                 "panels": [
                     {
                         "class": "alert_table",
-                        "span": 4,
+                        "gridPos": {
+                            "h": 12,
+                            "w": 8
+                        },
                         "title": "Active Alerts"
+                    },
+                    {
+                        "class": "alternator_tables"
                     },
                     {
                         "class": "bytes_panel",
@@ -89,8 +95,11 @@
                         "class": "us_panel",
                         "description": "The P95 Latencies per operation",
                         "gridPos": {
+                            "x": 16,
+                            "y": 13,
+                            "h": 6,
                             "w": 4
-                          },
+                        },
                         "targets": [
                             {
                                 "expr": "histogram_quantile(0.95, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=~\"$ops|$ops_batch\"}[$__rate_interval])>0) by (op, le))",
@@ -117,8 +126,11 @@
                         "class": "us_panel",
                         "description": "The P99 Latencies per operation",
                         "gridPos": {
+                            "x": 20,
+                            "y": 13,
+                            "h": 6,
                             "w": 4
-                          },
+                        },
                         "targets": [
                             {
                                 "expr": "histogram_quantile(0.99, sum(rate(scylla_alternator_op_latency_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=~\"$ops\"}[$__rate_interval])>0) by (op, le))",

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -3616,6 +3616,272 @@
             }
           }
         },
+    "alternator_tables": {
+      "type": "table",
+      "title": "Tables",
+      "gridPos": {
+         "h": 12,
+         "w": 8
+      },
+      "fieldConfig": {
+         "defaults": {
+            "custom": {
+            "align": "auto",
+            "footer": {
+               "reducers": []
+            },
+            "cellOptions": {
+               "type": "auto"
+            },
+            "inspect": false,
+            "filterable": true
+            },
+            "mappings": [],
+            "thresholds": {
+            "mode": "absolute",
+            "steps": [
+               {
+                  "value": null,
+                  "color": "green"
+               },
+               {
+                  "value": 80,
+                  "color": "red"
+               }
+            ]
+            },
+            "color": {
+            "mode": "thresholds"
+            },
+            "links": [
+            {
+               "title": "Table data",
+               "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__url_time_range}&var-table=${__data.fields[0]}"
+            }
+            ]
+         },
+         "overrides": [
+            {
+            "matcher": {
+               "id": "byName",
+               "options": "cf"
+            },
+            "properties": [
+               {
+                  "id": "displayName",
+                  "value": "Table"
+               }
+            ]
+            },
+            {
+            "matcher": {
+               "id": "byName",
+               "options": "Value #A"
+            },
+            "properties": [
+               {
+                  "id": "displayName",
+                  "value": "OP/s"
+               },
+               {
+                  "id": "unit",
+                  "value": "ops"
+               },
+               {
+                  "id": "custom.width",
+                  "value": 120
+               },
+               {
+                  "id": "decimals",
+                  "value": 1
+               }
+            ]
+            },
+            {
+            "matcher": {
+               "id": "byName",
+               "options": "Value #B"
+            },
+            "properties": [
+               {
+                  "id": "displayName",
+                  "value": "Disk Usage"
+               },
+               {
+                  "id": "unit",
+                  "value": "decbytes"
+               },
+               {
+                  "id": "custom.width",
+                  "value": 120
+               }
+            ]
+            },
+            {
+            "matcher": {
+               "id": "byName",
+               "options": "Value #C"
+            },
+            "properties": [
+               {
+                  "id": "displayName",
+                  "value": "P50"
+               },
+               {
+                  "id": "unit",
+                  "value": "µs"
+               },
+               {
+                  "id": "custom.width",
+                  "value": 120
+               }
+            ]
+            },
+            {
+            "matcher": {
+               "id": "byName",
+               "options": "Value #D"
+            },
+            "properties": [
+               {
+                  "id": "displayName",
+                  "value": "P95"
+               },
+               {
+                  "id": "custom.width",
+                  "value": 120
+               },
+               {
+                  "id": "unit",
+                  "value": "µs"
+               }
+            ]
+            },
+            {
+            "matcher": {
+               "id": "byName",
+               "options": "Value #E"
+            },
+            "properties": [
+               {
+                  "id": "displayName",
+                  "value": "P99"
+               },
+               {
+                  "id": "unit",
+                  "value": "µs"
+               },
+               {
+                  "id": "custom.width",
+                  "value": 120
+               }
+            ]
+            }
+         ]
+      },
+      "transformations": [
+         {
+            "id": "joinByField",
+            "options": {
+            "byField": "cf",
+            "mode": "outer"
+            }
+         },
+         {
+            "id": "filterFieldsByName",
+            "options": {
+            "include": {
+               "names": [
+                  "cf",
+                  "Value #A",
+                  "Value #B",
+                  "Value #C",
+                  "Value #D",
+                  "Value #E"
+               ]
+            }
+            }
+         }
+      ],
+      "targets": [
+         {
+            "refId": "A",
+            "editorMode": "code",
+            "expr": "sum(rate(scylla_alternator_table_operation{ks=~\"alternator_.*\"}[10m])) by (cf)",
+            "legendFormat": "__auto",
+            "range": false,
+            "format": "table",
+            "instant": true,
+            "exemplar": false,
+            "hide": false
+         },
+         {
+            "refId": "B",
+            "expr": "sum(scylla_column_family_total_disk_space{ks=~\"alternator_.*\"}) by (cf)",
+            "range": false,
+            "instant": true,
+            "datasource": {
+            "uid": "P1809F7CD0C75ACF3",
+            "type": "prometheus"
+            },
+            "hide": false,
+            "editorMode": "code",
+            "legendFormat": "__auto",
+            "format": "table",
+            "exemplar": false
+         },
+         {
+            "refId": "C",
+            "expr": " ((sum(rate(scylla_alternator_table_op_latency_bucket{ks=~\"alternator_.*\"}[2m])) by (cf) < 1)*0 or on(cf) histogram_quantile(0.5, sum(rate(scylla_alternator_table_op_latency_bucket{ks=~\"alternator_.*\"}[2m])) by (cf, le))) ",
+            "range": false,
+            "instant": true,
+            "datasource": {
+            "uid": "P1809F7CD0C75ACF3",
+            "type": "prometheus"
+            },
+            "hide": false,
+            "editorMode": "code",
+            "legendFormat": "__auto",
+            "format": "table",
+            "exemplar": false
+         },
+         {
+            "refId": "D",
+            "expr": " ((sum(rate(scylla_alternator_table_op_latency_bucket{ks=~\"alternator_.*\"}[2m])) by (cf) < 1)*0 or on(cf) histogram_quantile(0.95, sum(rate(scylla_alternator_table_op_latency_bucket{ks=~\"alternator_.*\"}[2m])) by (cf, le))) ",
+            "range": false,
+            "instant": true,
+            "datasource": {
+            "uid": "P1809F7CD0C75ACF3",
+            "type": "prometheus"
+            },
+            "hide": false,
+            "editorMode": "code",
+            "legendFormat": "__auto",
+            "format": "table",
+            "exemplar": false
+         },
+         {
+            "refId": "E",
+            "expr": " ((sum(rate(scylla_alternator_table_op_latency_bucket{ks=~\"alternator_.*\"}[2m])) by (cf) < 1)*0 or on(cf) histogram_quantile(0.99, sum(rate(scylla_alternator_table_op_latency_bucket{ks=~\"alternator_.*\"}[2m])) by (cf, le))) ",
+            "range": false,
+            "instant": true,
+            "datasource": {
+            "uid": "P1809F7CD0C75ACF3",
+            "type": "prometheus"
+            },
+            "hide": false,
+            "editorMode": "code",
+            "legendFormat": "__auto",
+            "format": "table",
+            "exemplar": false
+         }
+      ],
+      "datasource": "prometheus",
+      "options": {
+         "showHeader": true,
+         "cellHeight": "sm"
+      }
+   },
     "dc_nodes_table":{
       "datasource":"prometheus",
       "id":"auto",


### PR DESCRIPTION
This patch adds a table of tables to the Alternator with the number of operations, total disk space used, P50, P95, and P99. It is helpful when there are lots of tables, and it's unclear which are the active tables.
<img width="928" height="402" alt="FireShot Capture 511 - Alternator-4 - Dashboards - Grafana -  graphs backoffice prd dbaas scyop net" src="https://github.com/user-attachments/assets/0f8a71b9-73b4-4add-9a08-f522dd01859b" />

