### PR TITLE
scylla-detailed: Use recording rule for reactor shard count in latency panels

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -444,14 +444,14 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "($topbottom([[filter_limit]], wlatencya{by=\"[[by]]\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  count(scylla_reactor_utilization))",
+                                "expr": "($topbottom([[filter_limit]], wlatencya{by=\"[[by]]\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  scylla:reactor_shard_count)",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{scheduling_group_name}} {{cluster}} {{dc}} {{instance}} {{shard}}",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "$func(wlatencya{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool count(scylla_reactor_utilization))* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  count(scylla_reactor_utilization)))",
+                                "expr": "$func(wlatencya{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool scylla:reactor_shard_count)* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  scylla:reactor_shard_count))",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{func}} {{scheduling_group_name}} {{cluster}} {{dc}} {{instance}}",
                                 "refId": "B",
@@ -466,7 +466,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "($topbottom([[filter_limit]], wlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg|$\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  count(scylla_reactor_utilization))",
+                                "expr": "($topbottom([[filter_limit]], wlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg|$\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  scylla:reactor_shard_count)",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{scheduling_group_name}} {{cluster}} {{dc}} {{instance}} {{shard}}",
                                 "metric": "",
@@ -474,7 +474,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "$func(wlatencyp95{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool count(scylla_reactor_utilization))* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  count(scylla_reactor_utilization)))",
+                                "expr": "$func(wlatencyp95{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool scylla:reactor_shard_count)* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  scylla:reactor_shard_count))",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{func}} {{scheduling_group_name}} {{cluster}} {{dc}} {{instance}}",
                                 "refId": "B",
@@ -489,7 +489,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "($topbottom([[filter_limit]], wlatencyp99{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  count(scylla_reactor_utilization))",
+                                "expr": "($topbottom([[filter_limit]], wlatencyp99{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  scylla:reactor_shard_count)",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{scheduling_group_name}} {{cluster}} {{dc}} {{instance}} {{shard}}",
                                 "metric": "",
@@ -497,7 +497,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "$func(wlatencyp99{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool count(scylla_reactor_utilization))* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  count(scylla_reactor_utilization)))",
+                                "expr": "$func(wlatencyp99{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool scylla:reactor_shard_count)* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  scylla:reactor_shard_count))",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{func}} {{scheduling_group_name}} {{cluster}} {{dc}} {{instance}}",
                                 "refId": "B",
@@ -527,14 +527,14 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "($topbottom([[filter_limit]], rlatencya{by=\"[[by]]\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  count(scylla_reactor_utilization))",
+                                "expr": "($topbottom([[filter_limit]], rlatencya{by=\"[[by]]\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  scylla:reactor_shard_count)",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{scheduling_group_name}} {{cluster}} {{dc}} {{instance}} {{shard}}",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "$func(rlatencya{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool count(scylla_reactor_utilization))* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  count(scylla_reactor_utilization)))",
+                                "expr": "$func(rlatencya{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool scylla:reactor_shard_count)* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  scylla:reactor_shard_count))",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{func}} {{scheduling_group_name}} {{cluster}} {{dc}} {{instance}}",
                                 "refId": "B",
@@ -549,7 +549,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "($topbottom([[filter_limit]], rlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  count(scylla_reactor_utilization))",
+                                "expr": "($topbottom([[filter_limit]], rlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  scylla:reactor_shard_count)",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{scheduling_group_name}} {{cluster}} {{dc}} {{instance}} {{shard}}",
                                 "metric": "",
@@ -557,7 +557,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "$func(rlatencyp95{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool count(scylla_reactor_utilization))* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  count(scylla_reactor_utilization)))",
+                                "expr": "$func(rlatencyp95{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool scylla:reactor_shard_count)* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  scylla:reactor_shard_count))",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{func}} {{scheduling_group_name}} {{cluster}} {{dc}} {{instance}}",
                                 "refId": "B",
@@ -572,7 +572,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "($topbottom([[filter_limit]], rlatencyp99{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  count(scylla_reactor_utilization))",
+                                "expr": "($topbottom([[filter_limit]], rlatencyp99{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  scylla:reactor_shard_count)",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{scheduling_group_name}} {{cluster}} {{dc}} {{instance}} {{shard}}",
                                 "metric": "",
@@ -580,7 +580,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "$func(rlatencyp99{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool count(scylla_reactor_utilization))* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  count(scylla_reactor_utilization)))",
+                                "expr": "$func(rlatencyp99{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool scylla:reactor_shard_count)* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  scylla:reactor_shard_count))",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{func}} {{scheduling_group_name}} {{cluster}} {{dc}} {{instance}}",
                                 "refId": "B",
@@ -2575,14 +2575,14 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "($topbottom([[filter_limit]], wlatencya{by=\"[[by]]\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  count(scylla_reactor_utilization))",
+                                "expr": "($topbottom([[filter_limit]], wlatencya{by=\"[[by]]\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  scylla:reactor_shard_count)",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{scheduling_group_name}} {{cluster}} {{dc}} {{instance}} {{shard}}",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "$func(wlatencya{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool count(scylla_reactor_utilization))* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  count(scylla_reactor_utilization)))",
+                                "expr": "$func(wlatencya{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool scylla:reactor_shard_count)* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  scylla:reactor_shard_count))",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{func}} {{scheduling_group_name}} {{cluster}} {{dc}} {{instance}}",
                                 "refId": "B",
@@ -2596,7 +2596,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "($topbottom([[filter_limit]], wlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg|$\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  count(scylla_reactor_utilization))",
+                                "expr": "($topbottom([[filter_limit]], wlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg|$\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  scylla:reactor_shard_count)",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{scheduling_group_name}} {{cluster}} {{dc}} {{instance}} {{shard}}",
                                 "metric": "",
@@ -2604,7 +2604,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "$func(wlatencyp95{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool count(scylla_reactor_utilization))* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  count(scylla_reactor_utilization)))",
+                                "expr": "$func(wlatencyp95{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool scylla:reactor_shard_count)* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  scylla:reactor_shard_count))",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{func}} {{scheduling_group_name}} {{cluster}} {{dc}} {{instance}}",
                                 "refId": "B",
@@ -2618,7 +2618,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "($topbottom([[filter_limit]], wlatencyp99{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  count(scylla_reactor_utilization))",
+                                "expr": "($topbottom([[filter_limit]], wlatencyp99{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  scylla:reactor_shard_count)",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{scheduling_group_name}} {{cluster}} {{dc}} {{instance}} {{shard}}",
                                 "metric": "",
@@ -2626,7 +2626,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "$func(wlatencyp99{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool count(scylla_reactor_utilization))* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  count(scylla_reactor_utilization)))",
+                                "expr": "$func(wlatencyp99{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool scylla:reactor_shard_count)* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  scylla:reactor_shard_count))",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{func}} {{scheduling_group_name}} {{cluster}} {{dc}} {{instance}}",
                                 "refId": "B",
@@ -2655,14 +2655,14 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "($topbottom([[filter_limit]], rlatencya{by=\"[[by]]\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  count(scylla_reactor_utilization))",
+                                "expr": "($topbottom([[filter_limit]], rlatencya{by=\"[[by]]\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  scylla:reactor_shard_count)",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{scheduling_group_name}} {{cluster}} {{dc}} {{instance}} {{shard}}",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "$func(rlatencya{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool count(scylla_reactor_utilization))* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  count(scylla_reactor_utilization)))",
+                                "expr": "$func(rlatencya{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool scylla:reactor_shard_count)* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  scylla:reactor_shard_count))",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{func}} {{scheduling_group_name}} {{cluster}} {{dc}} {{instance}}",
                                 "refId": "B",
@@ -2676,7 +2676,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "($topbottom([[filter_limit]], rlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  count(scylla_reactor_utilization))",
+                                "expr": "($topbottom([[filter_limit]], rlatencyp95{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  scylla:reactor_shard_count)",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{scheduling_group_name}} {{cluster}} {{dc}} {{instance}} {{shard}}",
                                 "metric": "",
@@ -2684,7 +2684,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "$func(rlatencyp95{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool count(scylla_reactor_utilization))* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  count(scylla_reactor_utilization)))",
+                                "expr": "$func(rlatencyp95{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool scylla:reactor_shard_count)* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  scylla:reactor_shard_count))",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{func}} {{scheduling_group_name}} {{cluster}} {{dc}} {{instance}}",
                                 "refId": "B",
@@ -2698,7 +2698,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "($topbottom([[filter_limit]], rlatencyp99{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  count(scylla_reactor_utilization))",
+                                "expr": "($topbottom([[filter_limit]], rlatencyp99{by=\"[[by]]\", instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}))/scalar($func(count(scylla_reactor_utilization) by (instance,shard)) ==bool  scylla:reactor_shard_count)",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{scheduling_group_name}} {{cluster}} {{dc}} {{instance}} {{shard}}",
                                 "metric": "",
@@ -2706,7 +2706,7 @@
                                 "step": 1
                             },
                             {
-                                "expr": "$func(rlatencyp99{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool count(scylla_reactor_utilization))* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  count(scylla_reactor_utilization)))",
+                                "expr": "$func(rlatencyp99{by=\"instance,shard\", instance=~\"[[node]]|$^\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"})by ([[by]], scheduling_group_name)/(scalar(count(count(scylla_reactor_utilization) by ([[by]])) != bool scylla:reactor_shard_count)* scalar($func(count(scylla_reactor_utilization) by (instance,shard)) !=bool  scylla:reactor_shard_count))",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{func}} {{scheduling_group_name}} {{cluster}} {{dc}} {{instance}}",
                                 "refId": "B",

--- a/prometheus/prom_rules/prometheus.latency.rules.yml
+++ b/prometheus/prom_rules/prometheus.latency.rules.yml
@@ -592,3 +592,5 @@ groups:
     expr: scylla_storage_proxy_coordinator_cas_read_latency_summary{quantile="0.5"}
   - record: caswlatencya
     expr: scylla_storage_proxy_coordinator_cas_write_latency_summary{quantile="0.5"}
+  - record: scylla:reactor_shard_count
+    expr: count(scylla_reactor_utilization)


### PR DESCRIPTION
## Summary
- Add `scylla:reactor_shard_count` recording rule that pre-computes `count(scylla_reactor_utilization)` (the total shard count across all nodes)
- Replace 36 inline evaluations of this expression across 24 latency panel queries in `scylla-detailed` with references to the recording rule
- On a 24h view with 15s step, this eliminates ~138K redundant `count()` evaluations that previously ran at every Prometheus evaluation step

## What changed
### Recording rule (`prometheus/prom_rules/prometheus.latency.rules.yml`)
Added:
```yaml
- record: scylla:reactor_shard_count
  expr: count(scylla_reactor_utilization)
```

### Dashboard (`grafana/scylla-detailed.template.json`)
Replaced all standalone `count(scylla_reactor_utilization)` references (those without a `by` clause) with `scylla:reactor_shard_count` in the latency panel expressions. The expressions with `by (instance,shard)` and `by ([[by]])` clauses are unchanged since they depend on Grafana variables.

## Testing
1. **Prometheus rule validation:** `promtool check rules` passes with `--lint=none` (pre-existing duplicate lint warnings for `_bucket` vs native histogram variants are unrelated)
2. **Dashboard generation:** `generate-dashboards.sh -v 2024.2` succeeds without errors
3. **JSON validation:** All generated dashboard JSON files are valid
4. **Expression verification:** 24 lines now reference `scylla:reactor_shard_count`; 24 `count(scylla_reactor_utilization) by (...)` expressions correctly remain unchanged

### Manual testing checklist
- [ ] Deploy updated rules and dashboards to a test environment
- [ ] Verify all 12 latency panels in "Latencies" section render data
- [ ] Verify all 12 latency panels in "Latencies - $sg" section render data
- [ ] Toggle `$func` variable (sum/avg) — both should work correctly
- [ ] Toggle `[[by]]` variable (instance/dc/cluster) — conditional normalization logic should activate/deactivate correctly
- [ ] Compare values side-by-side with an unmodified dashboard to confirm numerical equivalence