### PR TITLE
Use recording rules for write/read latency count fallback chains

### DIFF
--- a/grafana/scylla-detailed.template.json
+++ b/grafana/scylla-detailed.template.json
@@ -512,7 +512,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$topbottom([[filter_limit]], $func(rate(scylla_storage_proxy_coordinator_read_latency_summary_count{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]],scheduling_group_name) or on ([[by]],scheduling_group_name) $func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]],scheduling_group_name))",
+                                "expr": "$topbottom([[filter_limit]], $func(scylla:read_latency_count_rate{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}) by ([[by]],scheduling_group_name))",
                                 "intervalFactor": 1,
                                 "legendFormat": "{{scheduling_group_name}} {{cluster}} {{dc}} {{instance}} {{shard}}",
                                 "refId": "A",
@@ -1940,7 +1940,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$topbottom([[filter_limit]], $func(rate(scylla_storage_proxy_coordinator_cas_read_latency_summary_count{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval]))  by ([[by]]) or on([[by]]) $func(rate(scylla_storage_proxy_coordinator_cas_read_latency_count{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval]))  by ([[by]]))",
+                                "expr": "$topbottom([[filter_limit]], $func(scylla:cas_read_latency_count_rate{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"})  by ([[by]]))",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -2005,7 +2005,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$topbottom([[filter_limit]], $func(rate(scylla_storage_proxy_coordinator_cas_write_latency_summary_count{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]]) or on ([[by]]) ($func(rate(scylla_storage_proxy_coordinator_cas_write_latency_count{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])))",
+                                "expr": "$topbottom([[filter_limit]], $func(scylla:cas_write_latency_count_rate{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]]))",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -2345,7 +2345,7 @@
                         "span": 4,
                         "targets": [
                             {
-                                "expr": "$topbottom([[filter_limit]], $func(rate(scylla_cdc_operations_failed{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[$__rate_interval])) by ([[by]])/($func(rate(scylla_storage_proxy_coordinator_cas_read_latency_summary_count{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]]) or on ([[by]]) $func(rate(scylla_storage_proxy_coordinator_cas_read_latency_count{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]]) + 1))",
+                                "expr": "$topbottom([[filter_limit]], $func(rate(scylla_cdc_operations_failed{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\"}[$__rate_interval])) by ([[by]])/($func(scylla:cas_read_latency_count_rate{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}) by ([[by]]) + 1))",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -2560,7 +2560,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$topbottom([[filter_limit]], $func(rate(scylla_storage_proxy_coordinator_write_latency_summary_count{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]]) or on([[by]]) $func(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]]))",
+                                "expr": "$topbottom([[filter_limit]], $func(scylla:write_latency_count_rate{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}) by ([[by]]))",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -2640,7 +2640,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$topbottom([[filter_limit]], $func(rate(scylla_storage_proxy_coordinator_read_latency_summary_count{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]]) or on ([[by]]) $func(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]]))",
+                                "expr": "$topbottom([[filter_limit]], $func(scylla:read_latency_count_rate{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}) by ([[by]]))",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "refId": "A",
@@ -2784,7 +2784,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$topbottom([[filter_limit]], sum(rate(scylla_transport_cql_request_bytes{kind=~\"QUERY|EXECUTE\",instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_write_latency_summary_count{instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]]) or on([[by]]) sum(rate(scylla_storage_proxy_coordinator_write_latency_count{instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]])))",
+                                "expr": "$topbottom([[filter_limit]], sum(rate(scylla_transport_cql_request_bytes{kind=~\"QUERY|EXECUTE\",instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]])/(sum(scylla:write_latency_count_rate{instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}) by ([[by]])))",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",
@@ -2800,7 +2800,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "$topbottom([[filter_limit]], sum(rate(scylla_transport_cql_response_bytes{kind=~\"QUERY|EXECUTE\",instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]])/(sum(rate(scylla_storage_proxy_coordinator_read_latency_summary_count{instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]]) or on ([[by]]) sum(rate(scylla_storage_proxy_coordinator_read_latency_count{instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]])))",
+                                "expr": "$topbottom([[filter_limit]], sum(rate(scylla_transport_cql_response_bytes{kind=~\"QUERY|EXECUTE\",instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]])/(sum(scylla:read_latency_count_rate{instance=~\"[[node]]|^$\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]|$^\",scheduling_group_name=~\"$sg\"}) by ([[by]])))",
                                 "intervalFactor": 1,
                                 "legendFormat": "",
                                 "metric": "",

--- a/grafana/scylla-overview.template.json
+++ b/grafana/scylla-overview.template.json
@@ -288,14 +288,14 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "sum(rate(scylla_storage_proxy_coordinator_write_latency_count{cluster=\"$cluster\", dc=~\"$dc\"}[$__rate_interval])) by ([[by]]) or on([[by]]) sum(rate(scylla_storage_proxy_coordinator_write_latency_summary_count{cluster=\"$cluster\", dc=~\"$dc\"}[$__rate_interval])) by ([[by]])",
+                                "expr": "sum(scylla:write_latency_count_rate{cluster=\"$cluster\", dc=~\"$dc\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Writes {{instance}}",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                              "expr": "sum(rate(scylla_storage_proxy_coordinator_write_latency_count{cluster=\"$cluster\", dc=~\"$dc\"}[$__rate_interval] offset 1d)) or on ([[by]]) sum(rate(scylla_storage_proxy_coordinator_write_latency_summary_count{cluster=\"$cluster\", dc=~\"$dc\"}[$__rate_interval] offset 1d))",
+                              "expr": "sum(scylla:write_latency_count_rate{cluster=\"$cluster\", dc=~\"$dc\"} offset 1d) by ([[by]])",
                               "legendFormat": "1 Day Ago",
                               "interval": "",
                               "intervalFactor": 1,
@@ -303,7 +303,7 @@
                               "step": 1
                             },
                             {
-                              "expr": "sum(rate(scylla_storage_proxy_coordinator_write_latency_count{cluster=\"$cluster\", dc=~\"$dc\"}[$__rate_interval] offset 1w)) or on ([[by]]) sum(rate(scylla_storage_proxy_coordinator_write_latency_summary_count{cluster=\"$cluster\", dc=~\"$dc\"}[$__rate_interval] offset 1w))",
+                              "expr": "sum(scylla:write_latency_count_rate{cluster=\"$cluster\", dc=~\"$dc\"} offset 1w) by ([[by]])",
                               "legendFormat": "1 Week Ago",
                               "interval": "",
                               "intervalFactor": 1,
@@ -379,21 +379,21 @@
                         },
                         "targets": [
                             {
-                                "expr": "sum(rate(scylla_storage_proxy_coordinator_read_latency_count{cluster=\"$cluster\", dc=~\"$dc\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]]) or on([[by]]) sum(rate(scylla_storage_proxy_coordinator_read_latency_summary_count{cluster=\"$cluster\", dc=~\"$dc\",scheduling_group_name=~\"$sg\"}[$__rate_interval])) by ([[by]])",
+                                "expr": "sum(scylla:read_latency_count_rate{cluster=\"$cluster\", dc=~\"$dc\",scheduling_group_name=~\"$sg\"}) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "Reads {{instance}}",
                                 "refId": "A",
                                 "step": 1
                             },
                             {
-                                "expr": "sum(rate(scylla_storage_proxy_coordinator_read_latency_count{cluster=\"$cluster\", dc=~\"$dc\",scheduling_group_name=~\"$sg\"}[$__rate_interval] offset 1d)) or on ([[by]]) sum(rate(scylla_storage_proxy_coordinator_read_latency_summary_count{cluster=\"$cluster\", dc=~\"$dc\",scheduling_group_name=~\"$sg\"}[$__rate_interval] offset 1d))",
+                                "expr": "sum(scylla:read_latency_count_rate{cluster=\"$cluster\", dc=~\"$dc\",scheduling_group_name=~\"$sg\"} offset 1d) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "1 Day Ago",
                                 "refId": "B",
                                 "step": 1
                             },
                             {
-                                "expr": "sum(rate(scylla_storage_proxy_coordinator_read_latency_count{cluster=\"$cluster\", dc=~\"$dc\",scheduling_group_name=~\"$sg\"}[$__rate_interval] offset 1w)) or on ([[by]]) sum(rate(scylla_storage_proxy_coordinator_read_latency_summary_count{cluster=\"$cluster\", dc=~\"$dc\",scheduling_group_name=~\"$sg\"}[$__rate_interval] offset 1w))",
+                                "expr": "sum(scylla:read_latency_count_rate{cluster=\"$cluster\", dc=~\"$dc\",scheduling_group_name=~\"$sg\"} offset 1w) by ([[by]])",
                                 "intervalFactor": 1,
                                 "legendFormat": "1 Week Ago",
                                 "refId": "C",

--- a/prometheus/prom_rules/prometheus.latency.rules.yml
+++ b/prometheus/prom_rules/prometheus.latency.rules.yml
@@ -592,3 +592,11 @@ groups:
     expr: scylla_storage_proxy_coordinator_cas_read_latency_summary{quantile="0.5"}
   - record: caswlatencya
     expr: scylla_storage_proxy_coordinator_cas_write_latency_summary{quantile="0.5"}
+  - record: scylla:write_latency_count_rate
+    expr: sum(rate(scylla_storage_proxy_coordinator_write_latency_count[60s])) by (cluster, dc, instance, shard, scheduling_group_name) or on(cluster, dc, instance, shard, scheduling_group_name) sum(rate(scylla_storage_proxy_coordinator_write_latency_summary_count[60s])) by (cluster, dc, instance, shard, scheduling_group_name)
+  - record: scylla:read_latency_count_rate
+    expr: sum(rate(scylla_storage_proxy_coordinator_read_latency_count[60s])) by (cluster, dc, instance, shard, scheduling_group_name) or on(cluster, dc, instance, shard, scheduling_group_name) sum(rate(scylla_storage_proxy_coordinator_read_latency_summary_count[60s])) by (cluster, dc, instance, shard, scheduling_group_name)
+  - record: scylla:cas_read_latency_count_rate
+    expr: sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_count[60s])) by (cluster, dc, instance, shard, scheduling_group_name) or on(cluster, dc, instance, shard, scheduling_group_name) sum(rate(scylla_storage_proxy_coordinator_cas_read_latency_summary_count[60s])) by (cluster, dc, instance, shard, scheduling_group_name)
+  - record: scylla:cas_write_latency_count_rate
+    expr: sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_count[60s])) by (cluster, dc, instance, shard, scheduling_group_name) or on(cluster, dc, instance, shard, scheduling_group_name) sum(rate(scylla_storage_proxy_coordinator_cas_write_latency_summary_count[60s])) by (cluster, dc, instance, shard, scheduling_group_name)


### PR DESCRIPTION
## Summary
- Add 4 recording rules that resolve the `_latency_count or _latency_summary_count` fallback once per evaluation interval instead of at every query
- Replace 6 fallback chain expressions in `scylla-overview` and 8 in `scylla-detailed` with references to these recording rules
- Eliminates double-evaluation of both `or` branches at every Prometheus evaluation step

## Background
ScyllaDB versions expose either summary-type (`_summary_count`) or histogram-type (`_latency_count`) metrics for coordinator latency. Dashboard queries use `or on()` fallback chains to handle both versions. Prometheus evaluates **both** sides of `or` before merging results, so each fallback query does 2x the work.

## What changed
### Recording rules (`prometheus/prom_rules/prometheus.latency.rules.yml`)
Added:
```yaml
- record: scylla:write_latency_count_rate
  expr: sum(rate(scylla_storage_proxy_coordinator_write_latency_count[60s])) by (cluster, dc, instance, shard, scheduling_group_name) or on(...) sum(rate(..._summary_count[60s])) by (...)
- record: scylla:read_latency_count_rate
  expr: <same pattern for reads>
- record: scylla:cas_read_latency_count_rate
  expr: <same pattern for CAS reads>
- record: scylla:cas_write_latency_count_rate
  expr: <same pattern for CAS writes>
```

### Dashboards
- `scylla-overview`: Writes/Reads panels (including `offset 1d` and `offset 1w` variants)
- `scylla-detailed`: Read/Write counts, CAS counts, CDC failed operations denominator, estimated message size denominators

## Testing
1. **`promtool check rules --lint=none`** passes (124 rules found)
2. **`generate-dashboards.sh -v 2024.2`** succeeds without errors
3. **All generated JSON files are valid**
4. **No `_summary_count.*or on` fallback patterns remain** in the updated dashboards

### Manual testing checklist
- [ ] Deploy updated rules and dashboards to a test environment
- [ ] Verify Writes/Reads panels in overview show data for current, 1-day-ago, and 1-week-ago
- [ ] Toggle `[[by]]` variable — all aggregation levels should work
- [ ] Verify LWT Reads/Writes panels in scylla-detailed show data
- [ ] Verify CDC failed operations panel in scylla-detailed shows data
- [ ] Verify estimated write/read message size panels show data
- [ ] Test with an older ScyllaDB version (summary metrics) to confirm backward compatibility through the recording rule
- [ ] Compare throughput values side-by-side with an unmodified dashboard