### PR TITLE
scylla-cql: Replace scylla_reactor_utilization*0 zero-fill with vector(0)

### DIFF
--- a/grafana/scylla-cql.template.json
+++ b/grafana/scylla-cql.template.json
@@ -825,7 +825,7 @@
                         "span": 3,
                         "targets": [
                             {
-                                "expr": "(sum(rate(scylla_storage_proxy_coordinator_reads_coordinator_outside_replica_set{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]]) or on() sum(scylla_reactor_utilization*0) by([[by]]))",
+                                "expr": "(sum(rate(scylla_storage_proxy_coordinator_reads_coordinator_outside_replica_set{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]]) or on() vector(0))",
                                 "format": "time_series",
                                 "hide": false,
                                 "intervalFactor": 2,
@@ -833,7 +833,7 @@
                                 "legendFormat": "Reads {{dc}} {{instance}} {{shard}}"
                             },
                             {
-                                "expr": "(sum(rate(scylla_storage_proxy_coordinator_writes_coordinator_outside_replica_set{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]]) or on() sum(scylla_reactor_utilization*0) by([[by]]))",
+                                "expr": "(sum(rate(scylla_storage_proxy_coordinator_writes_coordinator_outside_replica_set{instance=~\"[[node]]\",cluster=\"$cluster\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]]) or on() vector(0))",
                                 "format": "time_series",
                                 "hide": false,
                                 "intervalFactor": 2,


### PR DESCRIPTION
## Summary
- Replace `sum(scylla_reactor_utilization*0) by([[by]])` with `vector(0)` in 2 expressions in the Non-Token Aware Queries panel

## Background
The Non-Token Aware Queries panel uses `or on() sum(scylla_reactor_utilization*0) by([[by]])` as a fallback to produce zero-value series when there are no non-token-aware requests. This queries the high-cardinality `scylla_reactor_utilization` metric (one series per shard on every node), selects all series, multiplies them by zero, then aggregates — just to produce a zero.

Since the fallback uses `or on()` which discards label matching, `vector(0)` produces the same result without querying any metric at all.

## Scope
Only the 2 occurrences in `scylla-cql.template.json` are changed. The `cache_hit_rate*0` occurrences in `types.json` and `scylla-ks.template.json` are **intentionally not changed** because they use the `*0` pattern for label preservation (matching on `ks,cf` labels) without `on()`, so `vector(0)` would not be a correct replacement there.

## Testing
1. **`generate-dashboards.sh -v 2024.2`** succeeds without errors
2. **All generated JSON files are valid**
3. **No `reactor_utilization*0` patterns remain** in the generated CQL dashboard

### Manual testing checklist
- [ ] Open the CQL dashboard "Non-Token Aware Queries" panel
- [ ] Verify it shows data when there are non-token-aware requests
- [ ] Verify it shows 0 (not "No Data") when there are no non-token-aware requests
- [ ] Verify the graph panel (refId A reads, refId B writes) renders correctly with the [[by]] variable at all levels