### PR TITLE
types.json: Update restart and stall annotations intervals

### DIFF
--- a/grafana/types.json
+++ b/grafana/types.json
@@ -6065,7 +6065,7 @@
    "annotation_restart":{
       "datasource":"prometheus",
       "enable":true,
-      "expr":"resets(scylla_gossip_heart_beat{cluster=\"$cluster\"}[$__rate_interval])>0",
+      "expr":"resets(scylla_gossip_heart_beat{cluster=\"$cluster\"}[5m])>0",
       "hide":false,
       "iconColor":"rgba(255, 96, 96, 1)",
       "limit":100,
@@ -6086,7 +6086,7 @@
    "annotation_stall":{
       "datasource":"prometheus",
       "enable":false,
-      "expr":"changes(scylla_stall_detector_reported{cluster=\"$cluster\"}[$__rate_interval])>0",
+      "expr":"changes(scylla_stall_detector_reported{cluster=\"$cluster\"}[5m])>0",
       "hide":false,
       "iconColor":"rgba(255, 96, 96, 1)",
       "limit":100,


### PR DESCRIPTION
For whatever reason, Prometheus does not always identify a counter restart when the duration is too short.
This patch set it to 5m.

Fixes #2833