### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/call_sync_milestone_to_jira.yml
+++ b/.github/workflows/call_sync_milestone_to_jira.yml
@@ -4,6 +4,9 @@ on:
   milestone:
     types: [created, closed]
 
+permissions:
+  contents: read
+
 jobs:
   sync-milestone-to-jira:
     uses: scylladb/github-automation/.github/workflows/main_sync_milestone_to_jira_release.yml@main


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylla-monitoring/security/code-scanning/3](https://github.com/scylladb/scylla-monitoring/security/code-scanning/3)

Add an explicit `permissions` block in `.github/workflows/call_sync_milestone_to_jira.yml` to enforce least privilege for the workflow token.  
The safest minimal fix without changing functionality is to define read-only baseline permissions at the workflow root:

- `contents: read`

This satisfies the CodeQL requirement for explicit restriction and avoids granting write scopes unnecessarily.  
Change location: directly under `on:` block (or after it) and before `jobs:` in `.github/workflows/call_sync_milestone_to_jira.yml`.

No imports, methods, or dependency changes are needed (YAML workflow edit only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
