### PR TITLE
packer: make monitor images public and add branch tag

### DIFF
--- a/.github/workflows/build-cloud-images.yaml
+++ b/.github/workflows/build-cloud-images.yaml
@@ -42,19 +42,23 @@ jobs:
       - name: Determine Scylla Monitor version
         run: |
           if ${{ github.event_name == 'workflow_dispatch' }}; then
-            echo "MONITOR_VERSION=${{ github.event.inputs.monitor_version }}" >> $GITHUB_ENV
+            MONITOR_VERSION="${{ github.event.inputs.monitor_version }}"
           elif ${{ github.event_name == 'release' }}; then
-            echo "MONITOR_VERSION=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+            MONITOR_VERSION="${{ github.event.release.tag_name }}"
           else
             echo "Missing Scylla Monitor version - Workflow cannot continue"
             exit 1
           fi
+          # Version line for the `branch` tag, e.g. 4.16.0-rc0 -> 4.16 (raw version if no X.Y match)
+          MONITOR_BRANCH="$(echo "$MONITOR_VERSION" | sed -E 's/^[^0-9]*([0-9]+\.[0-9]+).*/\1/')"
+          echo "MONITOR_VERSION=$MONITOR_VERSION" >> $GITHUB_ENV
+          echo "MONITOR_BRANCH=$MONITOR_BRANCH" >> $GITHUB_ENV
 
       - name: Build Images
         run: |
           packer plugins install github.com/hashicorp/googlecompute
           packer plugins install github.com/hashicorp/amazon
-          packer build -var monitor_version="$MONITOR_VERSION" scylla-monitor-template.json
+          packer build -var monitor_version="$MONITOR_VERSION" -var monitor_branch="$MONITOR_BRANCH" scylla-monitor-template.json
         working-directory: packer
 
       - name: Archive Packer manifest

--- a/packer/scylla-monitor-template.json
+++ b/packer/scylla-monitor-template.json
@@ -34,6 +34,8 @@
           "delete_on_termination": true
         }
       ],
+      "ami_groups": ["all"],
+      "snapshot_groups": ["all"],
       "ami_org_arns": [
         "arn:aws:organizations::978072043225:organization/o-o561yy1rs6"
       ],
@@ -45,7 +47,8 @@
       ],
       "tags": {
         "Name": "{{ user `monitor_image_name` }}",
-        "scylladb-monitor-version": "{{ user `monitor_version`| clean_resource_name }}"
+        "scylladb-monitor-version": "{{ user `monitor_version`| clean_resource_name }}",
+        "branch": "branch-{{ user `monitor_branch`| clean_resource_name }}"
       }
     },
     {
@@ -68,7 +71,8 @@
       "disk_size": 40,
       "disk_type": "pd-balanced",
       "image_labels": {
-        "scylladb-monitor-version": "{{ user `monitor_version`| clean_resource_name }}"
+        "scylladb-monitor-version": "{{ user `monitor_version`| clean_resource_name }}",
+        "branch": "branch-{{ user `monitor_branch`| clean_resource_name }}"
       },
       "labels": {
         "keep": 1,
@@ -134,6 +138,7 @@
   ],
   "variables": {
     "monitor_version": "",
+    "monitor_branch": "",
     "monitor_image_name": "scylladb-monitor-{{ user `monitor_version` | replace_all \".\" \"-\" }}-{{ isotime \"2006-01-02t03-04-05z\" }}",
 
     "aws_region": "us-east-1",


### PR DESCRIPTION
2 changes:
- Make scylla-monitoring AWS images (and their snapshots) public during release.
- Add a `branch` tag (AWS) and label (GCE) with the version line (e.g. branch-4.16), derived from the release version in the workflow.

The `scylladb-monitor-version` tag (AWS: 4.16.0) and label (GCE: 4-16-0) remain unchanged.

Today each release requires a manual edit in SCT, which pins the monitor image by its exact name. With a stable `branch` tag, SCT can instead select the latest image of a release line.

Fixes: https://scylladb.atlassian.net/browse/RELENG-179