### PR TITLE
Add image ARM support

### DIFF
--- a/.github/workflows/build-cloud-images.yaml
+++ b/.github/workflows/build-cloud-images.yaml
@@ -58,7 +58,8 @@ jobs:
         run: |
           packer plugins install github.com/hashicorp/googlecompute
           packer plugins install github.com/hashicorp/amazon
-          packer build -var monitor_version="$MONITOR_VERSION" -var monitor_branch="$MONITOR_BRANCH" scylla-monitor-template.json
+          packer build -var monitor_version="$MONITOR_VERSION" -var monitor_branch="$MONITOR_BRANCH" -var arch="amd64" scylla-monitor-template.json
+          packer build -only=amazon-ebs -var monitor_version="$MONITOR_VERSION" -var monitor_branch="$MONITOR_BRANCH" -var arch=arm64 scylla-monitor-template.json
         working-directory: packer
 
       - name: Archive Packer manifest

--- a/packer/README.md
+++ b/packer/README.md
@@ -27,8 +27,7 @@ packer build -only=googlecompute -var monitor_version="4.6.1" scylla-monitor-tem
 ```
 ## Variables
 
-  
-The Scylla Monitor Image uses default variables that are declared in the packer template file, for example `aws_source_ami`, `gcp_project_id` etc.  
+The Scylla Monitor Image uses default variables that are declared in the packer template file, for example `aws_source_ami`, `gcp_project_id` etc.
 You can override these default variables by creating a `variables.json` with the desired variable values, for example:
 
 ```json
@@ -43,6 +42,27 @@ And when running the packer build command, include the `-var-file` option to spe
 
 ```shell
 packer build -var-file=variables.json scylla-monitor-template.json
+```
+
+### Architecture
+
+By default the image is built for `amd64`. To build an ARM image, pass `--arch arm64`:
+
+```shell
+packer build -var monitor_version="4.6.1" -var arch=arm64 scylla-monitor-template.json
+```
+
+### AWS AMI regions
+
+By default the AMI is copied to all production regions: `us-west-2,us-east-2,eu-west-2,eu-west-1,eu-central-1,eu-north-1,eu-west-3,ca-central-1`.
+To limit the copy to a specific region or set of regions (useful for testing), override `aws_ami_regions`:
+
+```shell
+# Single region
+packer build -var monitor_version="4.6.1" -var aws_ami_regions=us-east-1 scylla-monitor-template.json
+
+# Multiple specific regions
+packer build -var monitor_version="4.6.1" -var aws_ami_regions=us-east-1,eu-west-1 scylla-monitor-template.json
 ```
 
 

--- a/packer/files/node_exporter_install
+++ b/packer/files/node_exporter_install
@@ -22,18 +22,24 @@
 
 import os
 import sys
-import tarfile
+import shlex
+import subprocess
 from scylla_util import *
 import argparse
+import tarfile
 
-VERSION='1.11.1-1'
-INSTALL_DIR=scylladir()+'/Prometheus/node_exporter'
+VERSION='1.11.1-2'
+
+def run(cmd):
+    subprocess.check_call(shlex.split(cmd))
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Download and install prometheus node_exporter')
     parser.add_argument('-F', '--force', action='store_true', default=False, help='Force re-installation when node_exporter is already installed')
+    parser.add_argument('--arch', default='amd64', help='Architecture to use (amd64/arm64)')
     args = parser.parse_args()
     force = args.force
+    arch = args.arch
     if not is_nonroot() and os.getuid() > 0:
         print('Requires root permission.')
         sys.exit(1)
@@ -55,18 +61,12 @@ if __name__ == '__main__':
         print('app-metrics/node_exporter does not install systemd service files, please fill a bug if you need them.')
         sys.exit(1)
     else:
-        data = curl('https://github.com/scylladb/scylladb-node-exporter/releases/download/v{version}/node_exporter-{version}.linux-amd64.tar.gz'.format(version=VERSION), byte=True)
-        with open('/var/tmp/node_exporter-{version}.linux-amd64.tar.gz'.format(version=VERSION), 'wb') as f:
+        deb_file = '/var/tmp/scylla-node-exporter_{version}_{arch}.deb'.format(version=VERSION, arch=arch)
+        data = curl('https://s3.amazonaws.com/downloads.scylladb.com/downloads/scylla/node-exporter/deb/scylla-node-exporter_{version}_{arch}.deb'.format(
+            version=VERSION, arch=arch), byte=True)
+        with open(deb_file, 'wb') as f:
             f.write(data)
-        with tarfile.open('/var/tmp/node_exporter-{version}.linux-amd64.tar.gz'.format(version=VERSION)) as tf:
-            tf.extractall(INSTALL_DIR)
-        os.remove('/var/tmp/node_exporter-{version}.linux-amd64.tar.gz'.format(version=VERSION))
-        if node_exporter_p.exists():
-            node_exporter_p.unlink()
-        os.rename('{install_dir}/node_exporter-{version}.linux-amd64/node_exporter'.format(install_dir=INSTALL_DIR, version=VERSION), '/usr/bin/node_exporter')
-        subprocess.check_call(['restorecon', '-rv', '/usr/bin/node_exporter'])
-        node_exporter = systemd_unit('node-exporter.service')
-        node_exporter.enable()
-        node_exporter.start()
+        run('dpkg -i {deb}'.format(deb=deb_file))
+        os.remove(deb_file)
 
     print('node_exporter successfully installed')

--- a/packer/files/node_exporter_install
+++ b/packer/files/node_exporter_install
@@ -26,7 +26,6 @@ import shlex
 import subprocess
 from scylla_util import *
 import argparse
-import tarfile
 
 VERSION='1.11.1-2'
 

--- a/packer/files/scylla_monitoring_install_ami
+++ b/packer/files/scylla_monitoring_install_ami
@@ -84,7 +84,7 @@ def chdir(template_dir):
         print('cd ', dir)
     os.chdir(dir)
 
-def install_docker():
+def install_docker(arch='amd64'):
     if is_centos():
         run('yum install -y yum-utils device-mapper-persistent-data lvm2')
         run('yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo')
@@ -94,7 +94,7 @@ def install_docker():
         run('apt-get install -y apt-transport-https ca-certificates curl software-properties-common')
         run('curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o gpg')
         run('apt-key add ./gpg')
-        run('add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable"')
+        run('add-apt-repository "deb [arch={ARCH}] https://download.docker.com/linux/ubuntu focal stable"'.format(ARCH=arch))
         run('apt-cache policy docker-ce')
         run('apt-get install -y docker-ce')
     run('usermod -aG docker {_USER}'.format(_USER=USER))
@@ -157,7 +157,7 @@ def install_dbaas(version):
     run('sudo -u {_USER} ./generate-dashboards.sh -F -v master'.format(_USER=USER))
     run_monitoring()
 
-def install_node_exporter():
+def install_node_exporter(arch='amd64'):
     if not is_centos():
         run('apt-get install -y policycoreutils')
     run('cp {_HOME}/node-exporter.service /etc/systemd/system/')
@@ -168,7 +168,7 @@ def install_node_exporter():
         print(e.output)
     run('systemctl daemon-reload')
     try:
-        run('{_HOME}/node_exporter_install')
+        run('{_HOME}/node_exporter_install --arch {arch}'.format(arch=arch, _HOME=HOME_DIR))
     except Exception as e:
         print("node_exporter_install failed" + str(e))
         print(e.output)
@@ -186,6 +186,7 @@ if __name__ == '__main__':
     parser.add_argument('--do-not-move', action='store_true', default=False, help='For testing, do not move files, copy them instead')
     parser.add_argument('--swap-size', default=20, type=int, help='set the swap size in GB, set it to 0 for no swap')
     parser.add_argument('--no-autorun', default=False, action='store_true', help='Autorun will try to use user data to configure and run the system')
+    parser.add_argument('--arch', default='amd64', help='Architecture to use (amd64/arm64)')
     parser.add_argument('-d', '--dry-run', action='store_true', default=False, help='Dry run mode')
 
     args = parser.parse_args()
@@ -199,7 +200,7 @@ if __name__ == '__main__':
     install_pip_dep()
     get_swap_scripts()
     update_swap(args.swap_size)
-    install_docker()
+    install_docker(args.arch)
     install_monitoring(args.version)
     post_monitoring_installation(args)
     install_dependencies(args)
@@ -207,4 +208,4 @@ if __name__ == '__main__':
         install_dbaas(args.version)
     else:
         setup_monitoring()
-        install_node_exporter()
+        install_node_exporter(args.arch)

--- a/packer/scylla-monitor-template.json
+++ b/packer/scylla-monitor-template.json
@@ -6,13 +6,13 @@
       "ami_name": "{{ user `monitor_image_name` }}",
       "source_ami_filter": {
         "filters": {
-          "name": "ubuntu-minimal/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64*"
+          "name": "{{user (printf \"aws_source_ami_filter_name_%s\" (user \"arch\")) }}"
         },
         "owners": ["099720109477"],
         "most_recent": true
       },
-      "instance_type": "{{user `aws_instance_type`}}",
-      "ami_regions": "us-west-2,us-east-2,eu-west-2,eu-west-1,eu-central-1,eu-north-1,eu-west-3,ca-central-1",
+      "instance_type": "{{user (printf \"aws_instance_type_%s\" (user \"arch\")) }}",
+      "ami_regions": "{{user `aws_ami_regions`}}",
       "user_data_file": "files/user_data.txt",
       "subnet_filter": {
         "filters": {
@@ -48,16 +48,22 @@
       "tags": {
         "Name": "{{ user `monitor_image_name` }}",
         "scylladb-monitor-version": "{{ user `monitor_version`| clean_resource_name }}",
-        "branch": "branch-{{ user `monitor_branch`| clean_resource_name }}"
+        "branch": "branch-{{ user `monitor_branch`| clean_resource_name }}",
+        "arch": "{{ user `arch` }}"
+      },
+      "run_tags": {
+        "Name": "packer-build-{{ user `monitor_image_name` }}-builder",
+        "Owner": "monitor-build",
+        "arch": "{{ user `arch` }}"
       }
     },
     {
       "type": "googlecompute",
       "project_id": "{{user `gcp_project_id`}}",
       "zone": "{{user `gcp_zone`}}",
-      "source_image_family": "{{user `gcp_source_image_family`}}",
+      "source_image_family": "{{ user (printf \"gcp_source_image_family_%s\" (user \"arch\")) }}",
       "image_storage_locations": ["{{user `gcp_image_storage_location`}}"],
-      "machine_type": "{{user `gcp_instance_type`}}",
+      "machine_type": "{{ user (printf \"gcp_instance_type_%s\" (user \"arch\")) }}",
       "ssh_username": "{{user `gcp_ssh_username`}}",
       "ssh_timeout": "6m",
       "metadata": { "block-project-ssh-keys": "TRUE" },
@@ -72,7 +78,8 @@
       "disk_type": "pd-balanced",
       "image_labels": {
         "scylladb-monitor-version": "{{ user `monitor_version`| clean_resource_name }}",
-        "branch": "branch-{{ user `monitor_branch`| clean_resource_name }}"
+        "branch": "branch-{{ user `monitor_branch`| clean_resource_name }}",
+        "arch": "{{ user `arch` }}"
       },
       "labels": {
         "keep": 1,
@@ -139,19 +146,26 @@
   "variables": {
     "monitor_version": "",
     "monitor_branch": "",
-    "monitor_image_name": "scylladb-monitor-{{ user `monitor_version` | replace_all \".\" \"-\" }}-{{ isotime \"2006-01-02t03-04-05z\" }}",
+    "monitor_image_name": "scylladb-monitor-{{ user `monitor_version` | replace_all \".\" \"-\" }}-{{ user `arch` }}-branch-{{ user `monitor_branch` | replace_all \".\" \"-\" }}-{{ isotime \"2006-01-02t03-04-05z\" }}",
 
+    "arch": "amd64",
     "aws_region": "us-east-1",
-    "aws_instance_type": "c4.xlarge",
+    "aws_ami_regions": "us-west-2,us-east-2,eu-west-2,eu-west-1,eu-central-1,eu-north-1,eu-west-3,ca-central-1",
+    "aws_source_ami_filter_name_amd64": "ubuntu-minimal/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64*",
+    "aws_source_ami_filter_name_arm64": "ubuntu-minimal/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64*",
+    "aws_instance_type_amd64": "c4.xlarge",
+    "aws_instance_type_arm64": "c7g.xlarge",
     "aws_ssh_username": "ubuntu",
-    "aws_install_args": "--cloud aws --os ubuntu --verbose --version {{ user `monitor_version` }}",
+    "aws_install_args": "--cloud aws --os ubuntu --verbose --version {{ user `monitor_version` }} --arch {{ user `arch` }}",
 
     "gcp_project_id": "scylla-images",
     "gcp_zone": "europe-west1-b",
-    "gcp_source_image_family": "ubuntu-minimal-2404-lts-amd64",
+    "gcp_source_image_family_amd64": "ubuntu-minimal-2404-lts-amd64",
+    "gcp_source_image_family_arm64": "ubuntu-minimal-2404-lts-arm64",
     "gcp_image_storage_location": "europe-west1",
-    "gcp_instance_type": "n1-standard-1",
+    "gcp_instance_type_amd64": "n1-standard-1",
+    "gcp_instance_type_arm64": "t2a-standard-2",
     "gcp_ssh_username": "ubuntu",
-    "gcp_install_args": "--cloud gce --os ubuntu --verbose --version {{ user `monitor_version` }}"
+    "gcp_install_args": "--cloud gce --os ubuntu --verbose --version {{ user `monitor_version` }} --arch {{ user `arch` }}"
   }
 }


### PR DESCRIPTION
This update adds ARM64 (aarch64) architecture support to the Scylla Monitoring image builder,
enabling the creation of AMIs and GCP images for ARM-based instances.

After this series, you can pass the arch as a parameter to packer build:
```
packer build -only=amazon-ebs -var monitor_version="4.6.1" \
    -var arch=arm64 scylla-monitor-template.json
```
The github action was updated to create ARM-based images in AWS.