### PR TITLE
scylla-vector-search: switch from rate to deriv for gauge calculation

### DIFF
--- a/grafana/scylla-vector-search.template.json
+++ b/grafana/scylla-vector-search.template.json
@@ -311,7 +311,7 @@
                         "span": 2,
                         "class": "ops_panel",
                         "spec/title": "Index build rate",
-                        "spec/description": "Rate of new vectors being added to the index",
+                        "spec/description": "Rate of new vectors being added to the index or removed from the index",
                         "spec/vizConfig/spec/fieldConfig": {
                             "defaults": {
                                 "class": "fieldConfig_defaults",
@@ -319,7 +319,7 @@
                             },
                             "overrides": []
                         },
-                        "spec/data/spec/queries/0/spec/query/spec/expr": "avg(rate(index_size{index_name=\"$index\", instance=~\"$node\"}[$__rate_interval])) by ([[by]], index_name)",
+                        "spec/data/spec/queries/0/spec/query/spec/expr": "avg(deriv(index_size{index_name=\"$index\", instance=~\"$node\"}[$__rate_interval])) by ([[by]], index_name)",
                         "spec/data/spec/queries/0/spec/query/spec/legendFormat": "{{instance}} {{index_name}}"
                     },
                     {


### PR DESCRIPTION
Fixes https://scylladb.atlassian.net/browse/MONITOR-75