### PR TITLE
docs: update theme 1.9.3

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 requires-python = ">=3.12"
 dependencies = [
     "pygments>=2.18.0",
-    "sphinx-scylladb-theme>=1.9.2",
+    "sphinx-scylladb-theme>=1.9.3",
     "myst-parser>=5.0.0",
     "sphinx-autobuild>=2025.4.8",
     "sphinx>=9.0",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,7 +64,7 @@ current_branch = 'branch-' + '.'.join(current_version.split('.')[:2])
 rst_prolog = """
 .. |version| replace:: {current_version}
 .. |branch_version| replace:: {current_branch}
-.. |mon_root| replace::  `Scylla Monitoring Stack </>`__
+.. |mon_root| replace::  :doc:`Scylla Monitoring Stack </index>`
 """.format(current_version=current_version, current_branch=current_branch)
 
 # -- Options for not found extension

--- a/docs/source/install/monitor-without-docker.rst
+++ b/docs/source/install/monitor-without-docker.rst
@@ -3,7 +3,7 @@ Deploying Scylla Monitoring Stack Without Docker
 ================================================
 Introduction
 ------------
-The following instructions will help to deploy `Scylla Monitoring Stack <monitoring_stack>`_ in cases where you can not use the recommended Docker version.
+The following instructions will help to deploy :doc:`Scylla Monitoring Stack </install/monitoring-stack>` in cases where you can not use the recommended Docker version.
 
 Please note, Scylla recommends you use the Docker version as it will provide you with most updated, current Scylla Monitoring system.
 
@@ -26,7 +26,7 @@ We suggest that you follow the installation instruction of each of those product
 The main item to set an alert on is the available disk space in the monitoring system. Data is indefinitely accrued on the Prometheus data directory.
 The current monitoring solution does not churn data.
 
-.. note:: Confirm before installing, that your Grafana and Prometheus versions are supported by the Scylla Monitoring Stack version you want to install. Scylla-Monitoring follows the latest Prometheus and Grafana releases tightly. See the `Scylla Monitoring Stack Compatibility Matrix <stable/install/monitoring-stack.html#prerequisites>`_.
+.. note:: Confirm before installing, that your Grafana and Prometheus versions are supported by the Scylla Monitoring Stack version you want to install. Scylla-Monitoring follows the latest Prometheus and Grafana releases tightly. See the :ref:`Scylla Monitoring Stack Compatibility Matrix <monitoring-stack-prerequisites>`.
 
 Install Scylla Monitoring Stack
 -------------------------------
@@ -127,6 +127,8 @@ Promtail has a configuration file. You need to copy and modify the configuration
    cp loki/promtail/promtail_config.template.yml /etc/promtail/config.yml
 
 Edit ``/etc/promtail/config.yml`` and replace ``LOKI_IP`` with Loki's ip:port (i.e. localhost:3100)
+
+.. _install-prometheus:
 
 Install Prometheus
 ------------------

--- a/docs/source/install/monitoring-stack.rst
+++ b/docs/source/install/monitoring-stack.rst
@@ -10,6 +10,8 @@ For evaluation, you can run Scylla Monitoring Stack on any server (or laptop) th
 
 .. include:: min-prod-hw.rst
 
+.. _monitoring-stack-prerequisites:
+
 Prerequisites
 -------------
 
@@ -103,6 +105,8 @@ Prerequisites
    * - 3.4
      - 2.18.1
      - 6.7.3
+
+.. _docker-post-installation:
 
 Docker Post Installation
 ------------------------

--- a/docs/source/procedures/datadog/index.rst
+++ b/docs/source/procedures/datadog/index.rst
@@ -10,7 +10,7 @@ The integration consists of:
 3. Loading Scylla dashboard to Datadog.
 4. Optionally load Monitor (Alerts).
 
-.. note::  Scylla Cloud users, Check the cloud users `specific guide <cloud-integration>`_.
+.. note::  Scylla Cloud users, Check the cloud users :doc:`specific guide </procedures/datadog/cloud-integration>`.
 
 Scylla Monitoring Datadog Integration Overview
 ==============================================

--- a/docs/source/troubleshooting/monitor-troubleshoot.rst
+++ b/docs/source/troubleshooting/monitor-troubleshoot.rst
@@ -2,9 +2,7 @@ Troubleshoot Scylla Monitoring Stack
 ====================================
 
 
-This document describes steps that need to be done to troubleshoot monitoring problems when using `Grafana/Prometheus`_ monitoring tool.
-
-..  _`Grafana/Prometheus`: ../monitoring-apis
+This document describes steps that need to be done to troubleshoot monitoring problems when using :doc:`Grafana/Prometheus </reference/monitoring-apis>` monitoring tool.
 
 Problem
 ~~~~~~~
@@ -54,9 +52,7 @@ Files And Directory Permissions
    Avoid running Docker containers as root.
 
 The preferred way of running the container is using a non root user.
-See the `monitoring`_ Docker post-installation section.
-
-.. _`monitoring`: ../monitoring-stack#docker-post-installation
+See the :ref:`monitoring <docker-post-installation>` Docker post-installation section.
 
 
 If a container failed to start because of a permission problem, make sure
@@ -110,9 +106,7 @@ For example:
 
    ./start-all.sh -v 2024.1
 
-More on start-all.sh `options`_.
-
-..  _`options`: ../monitoring-stack/
+More on start-all.sh :doc:`options </install/monitoring-stack>`.
 
 
 Grafana Chart Shows Error (!) Sign
@@ -183,9 +177,7 @@ If only the latency graphs are missing, it is because of missing recording rules
 
 This issue can be avoided in a clean installation, so if you are upgrading, it is recommended to perform a clean installation.
 
-If you are using a standalone Prometheus server, make sure to copy the Prometheus configuration and recording rules as describe in `install without docker`_.
-
-.. _`install without docker`: /install/monitor-without-docker#install-prometheus
+If you are using a standalone Prometheus server, make sure to copy the Prometheus configuration and recording rules as describe in :ref:`install without docker <install-prometheus>`.
 
 Reducing the total number of metrics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/upgrade/upgrade-guide-from-monitoring-4.x-to-monitoring-4.y.rst
+++ b/docs/source/upgrade/upgrade-guide-from-monitoring-4.x-to-monitoring-4.y.rst
@@ -155,5 +155,5 @@ Run:
 Related Links
 =============
 
-* `ScyllaDB Monitoring </operating-scylla/monitoring/>`_
+* `ScyllaDB Monitoring <https://docs.scylladb.com/operating-scylla/monitoring/>`_
 * :doc:`Upgrade</upgrade/index>`

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -465,7 +465,7 @@ requires-dist = [
     { name = "sphinx", specifier = ">=9.0" },
     { name = "sphinx-autobuild", specifier = ">=2025.4.8" },
     { name = "sphinx-multiversion-scylla", specifier = ">=0.3.8" },
-    { name = "sphinx-scylladb-theme", specifier = ">=1.9.2" },
+    { name = "sphinx-scylladb-theme", specifier = ">=1.9.3" },
     { name = "sphinx-sitemap", specifier = ">=2.9.0" },
 ]
 
@@ -587,6 +587,33 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinx-llm"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+    { name = "sphinx-markdown-builder" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/23/fe184bf9c6761c2cd04dc5b5456b717f626143663a3004f628636a2f7b0e/sphinx_llm-0.4.1.tar.gz", hash = "sha256:0789185dcbbecc00b5e25aa3db6342b98dad6a9def96088a9e50fa0203fda090", size = 280250, upload-time = "2026-04-02T09:09:18.881Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/2b/a54c49b42b25a6eb6039daf882f06488812c28e32734e944b2f7b6f82554/sphinx_llm-0.4.1-py3-none-any.whl", hash = "sha256:d7c8ee2a6335636b628ea2b26cd1e1dee1f0cf9c40fe51b20f201af1c05b95f5", size = 28453, upload-time = "2026-04-02T09:09:17.632Z" },
+]
+
+[[package]]
+name = "sphinx-markdown-builder"
+version = "0.6.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "sphinx" },
+    { name = "tabulate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/58/0b7b9a7d071140b3705885d51932e8b62f520388c2772e4952189971727b/sphinx_markdown_builder-0.6.10.tar.gz", hash = "sha256:cd5acf88d52ea0146a712fd557404f10326dff3428a78ba928e59b1727fd4a86", size = 22688, upload-time = "2026-03-11T10:56:57.639Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/8f/9fecf3d081d5cd49eff83a17b9fef50ed741e6223ab3bb906de4ab0068f9/sphinx_markdown_builder-0.6.10-py3-none-any.whl", hash = "sha256:16d86738b9ac69fcbc86e373c31c6402c30af1fa8d98d0f62cc5f38bfe5fc26e", size = 16700, upload-time = "2026-03-11T10:56:56.135Z" },
+]
+
+[[package]]
 name = "sphinx-multiversion-scylla"
 version = "0.3.8"
 source = { registry = "https://pypi.org/simple" }
@@ -612,7 +639,7 @@ wheels = [
 
 [[package]]
 name = "sphinx-scylladb-theme"
-version = "1.9.2"
+version = "1.9.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -620,14 +647,15 @@ dependencies = [
     { name = "setuptools" },
     { name = "sphinx-collapse" },
     { name = "sphinx-copybutton" },
+    { name = "sphinx-llm" },
     { name = "sphinx-notfound-page" },
     { name = "sphinx-substitution-extensions" },
     { name = "sphinx-tabs" },
     { name = "sphinxcontrib-mermaid" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/31/92/e30549be27dfdbfb3a1bf52cbc5496c190230dd2d4e7a41c8bafada8f4a2/sphinx_scylladb_theme-1.9.2.tar.gz", hash = "sha256:f4319deeefcc446779375c2d9cbdd922eaf63da092a50def74247dd2156f1274", size = 1683295, upload-time = "2026-04-14T11:07:30.662Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/43/2c6ca729655d99c69a7970efe56345d4bf345a345511ce4dc247aa5380df/sphinx_scylladb_theme-1.9.3.tar.gz", hash = "sha256:2a80252d6a5bb1ef8b61b6af47db4b7cbdec9c056b339ad4bc2cee97604603ad", size = 1691127, upload-time = "2026-07-16T16:44:51.404Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/ff/9957eef93c1b46dbbccd66cb4766d513c1061961daaa60fcfc1a78b3bc20/sphinx_scylladb_theme-1.9.2-py3-none-any.whl", hash = "sha256:1d75463151693c3b31ef48b2401aa4db18953fc515b4061c6f127182242e0280", size = 1669961, upload-time = "2026-04-14T11:07:28.944Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0e/b79e97434339b4b935535709b5b20491451e5c5de5d4b90c8cafbdcc7c2f/sphinx_scylladb_theme-1.9.3-py3-none-any.whl", hash = "sha256:2b9eb999421711deb7ca0fbd5c287c668cdaee7bd41d19abf75b140e8e6982d4", size = 1674682, upload-time = "2026-07-16T16:44:49.644Z" },
 ]
 
 [[package]]
@@ -750,6 +778,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Updates docs theme to 1.9.3.

[CHANGELOG](https://github.com/scylladb/sphinx-scylladb-theme/blob/master/docs/source/upgrade/CHANGELOG.md#193---16-july-2026)