### PR TITLE
Add alternator metrics

### DIFF
--- a/grafana/alternator.template.json
+++ b/grafana/alternator.template.json
@@ -718,7 +718,7 @@
                                 "class": "percentunit_panel",
                                 "spec/title": "Expression Cache hit ratio $func by [[by]]",
                                 "spec/description": "Alterantor expression cache",
-                                "spec/data/spec/queries/0/spec/query/spec/expr": "$func(rate(scylla_alternator_expression_cache_hits{cluster=~\"$cluster|$^\", dc=~\"$dc\", instance=~\"[[node]]\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]],expression)/($func(rate(scylla_alternator_expression_cache_hits{cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]],expression) + $func(rate(scylla_alternator_expression_cache_misses{cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]],expression))"
+                                "spec/data/spec/queries/0/spec/query/spec/expr": "$func(rate(scylla_alternator_expression_cache_hits{cluster=~\"$cluster|$^\", dc=~\"$dc\", instance=~\"[[node]]\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]],expression)/($func(rate(scylla_alternator_expression_cache_hits{cluster=~\"$cluster|$^\", dc=~\"$dc\", instance=~\"[[node]]\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]],expression) + $func(rate(scylla_alternator_expression_cache_misses{cluster=~\"$cluster|$^\", dc=~\"$dc\", instance=~\"[[node]]\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]],expression))"
                             },
                             {
                                 "dashversion": [
@@ -748,7 +748,7 @@
                                 "class": "ops_panel",
                                 "spec/title": "Authorization failures $func by [[by]]",
                                 "spec/description": "Alternator authorization failures",
-                                "spec/data/spec/queries/0/spec/query/spec/expr": "$func(rate(scylla_alternator_authorization_failures{cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])"
+                                "spec/data/spec/queries/0/spec/query/spec/expr": "$func(rate(scylla_alternator_authorization_failures{cluster=~\"$cluster|$^\", dc=~\"$dc\", instance=~\"[[node]]\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])"
                             }
                         ],
                         "hideHeader": true

--- a/grafana/alternator.template.json
+++ b/grafana/alternator.template.json
@@ -20,7 +20,7 @@
                                 "class": "alert_table",
                                 "gridPos": {
                                     "h": 12,
-                                    "w": 8
+                                    "w": 6
                                 },
                                 "title": "Active Alerts"
                             },

--- a/grafana/alternator.template.json
+++ b/grafana/alternator.template.json
@@ -336,6 +336,11 @@
                                         "class": "graph_query",
                                         "spec/refId": "B",
                                         "spec/query/spec/expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchWriteItemSize\"}[$__rate_interval])) by ([[by]])/$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchWriteItem\"}[$__rate_interval])) by ([[by]])"
+                                    },
+                                    {
+                                        "class": "graph_query",
+                                        "spec/refId": "C",
+                                        "spec/query/spec/expr": "$func(rate(scylla_alternator_batch_item_count_histogram_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchWriteItem\"}[$__rate_interval])) by ([[by]])/$func(rate(scylla_alternator_batch_item_count_histogram_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchWriteItem\"}[$__rate_interval])) by ([[by]])"
                                     }
                                 ]
                             },
@@ -376,6 +381,11 @@
                                         "class": "graph_query",
                                         "spec/refId": "B",
                                         "spec/query/spec/expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchGetItemSize\"}[$__rate_interval])) by ([[by]])/$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchGetItem\"}[$__rate_interval])) by ([[by]])"
+                                    },
+                                    {
+                                        "class": "graph_query",
+                                        "spec/refId": "C",
+                                        "spec/query/spec/expr": "$func(rate(scylla_alternator_batch_item_count_histogram_sum{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchGetItem\"}[$__rate_interval])) by ([[by]])/$func(rate(scylla_alternator_batch_item_count_histogram_count{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchGetItem\"}[$__rate_interval])) by ([[by]])"
                                     }
                                 ]
                             },

--- a/grafana/alternator.template.json
+++ b/grafana/alternator.template.json
@@ -300,13 +300,20 @@
                                 "spec/data/spec/queries/0/spec/query/spec/expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"Scan\"}[$__rate_interval])) by ([[by]])"
                             },
                             {
-                                "span": 4,
+                                "span": 3,
+                                "class": "single_histogram_panel",
+                                "spec/title": "BatchWriteItem histogram",
+                                "spec/description": "The number of items processed as a result of BatchWriteItem over the entire cluster and selected time range",
+                                "spec/data/spec/queries/0/spec/query/spec/expr": "sum(increase(scylla_alternator_batch_item_count_histogram_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchWriteItem\"}[$__range])) by (le)"
+                            },
+                            {
+                                "span": 3,
                                 "class": "ops_panel",
                                 "spec/title": "BatchWriteItem $func by [[by]]",
                                 "spec/data/spec/queries/0/spec/query/spec/expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchWriteItem\"}[$__rate_interval])) by ([[by]])"
                             },
                             {
-                                "span": 4,
+                                "span": 3,
                                 "class": "ops_panel",
                                 "spec/title": "Operations from BatchWriteItem $func by [[by]]",
                                 "spec/description": "The number of items processed as a result of BatchWriteItem",
@@ -323,7 +330,7 @@
                                 ]
                             },
                             {
-                                "span": 4,
+                                "span": 3,
                                 "class": "ops_panel",
                                 "spec/title": "Average Batch size of BatchWriteItem $func by [[by]]",
                                 "spec/description": "The avarage batch size of BatchWriteItem",
@@ -345,13 +352,20 @@
                                 ]
                             },
                             {
-                                "span": 4,
+                                "span": 3,
+                                "class": "single_histogram_panel",
+                                "spec/title": "BatchGetItem histogram",
+                                "spec/description": "The number of items processed as a result of BatchGetItem over the entire cluster and selected time range",
+                                "spec/data/spec/queries/0/spec/query/spec/expr": "sum(increase(scylla_alternator_batch_item_count_histogram_bucket{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchGetItem\"}[$__range])) by (le)"
+                            },
+                            {
+                                "span": 3,
                                 "class": "ops_panel",
                                 "spec/title": "BatchGetItem $func by [[by]]",
                                 "spec/data/spec/queries/0/spec/query/spec/expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"BatchGetItem\"}[$__rate_interval])) by ([[by]])"
                             },
                             {
-                                "span": 4,
+                                "span": 3,
                                 "class": "ops_panel",
                                 "spec/title": "Operations from BatchGetItem $func by [[by]]",
                                 "spec/description": "The number of items processed as a result of BatchGetItem",
@@ -368,7 +382,7 @@
                                 ]
                             },
                             {
-                                "span": 4,
+                                "span": 3,
                                 "class": "ops_panel",
                                 "spec/title": "Average Batch size of BatchGetItem $func by [[by]]",
                                 "spec/description": "The avarage batch size of BatchGetItem",

--- a/grafana/alternator.template.json
+++ b/grafana/alternator.template.json
@@ -594,7 +594,7 @@
                             {
                                 "class": "plain_text",
                                 "span": 6,
-                                "spec/vizConfig/spec/options/content": "<h1 style=\"color:#FFF; background-color:#1250b0; line-height: 150%; padding-left: 5px\">Timeouts</h1>",
+                                "spec/vizConfig/spec/options/content": "<h1 style=\"color:#FFF; background-color:#1250b0; line-height: 150%; padding-left: 5px\">Timeouts and Errors</h1>",
                                 "spec/vizConfig/spec/options/mode": "html"
                             }
                         ],
@@ -644,6 +644,45 @@
                                 "spec/title": "HTTP New connections $func by [[by]]",
                                 "spec/description": "Rate of new HTTP connections creation. High number may indicate a problem",
                                 "spec/data/spec/queries/0/spec/query/spec/expr": "round($func(rate(scylla_httpd_connections_total{service=~\"http.?-alternator\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]], service))"
+                            },
+                            {
+                                "span": 3,
+                                "class": "requestsps_panel",
+                                "spec/title": "Blocked requests $func by [[by]]",
+                                "spec/description": "Requests that were blocked due to memory pressure.",
+                                "spec/data/spec/queries/0/spec/query/spec/expr": "$func(rate(scylla_alternator_requests_blocked_memory{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])"
+                            },
+                            {
+                                "span": 3,
+                                "class": "requestsps_panel",
+                                "spec/title": "Shed requests rate $func by [[by]]",
+                                "spec/description": "Rate Requests that were shed due to overload.",
+                                "spec/data/spec/queries/0/spec/query/spec/expr": "$func(rate(scylla_alternator_requests_shed{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])"
+                            },
+                            {
+                                "span": 3,
+                                "class": "requestsps_panel",
+                                "spec/title": "HTTP Requests rate $func by [[by]]",
+                                "spec/description": "Rate of HTTP requests served by Alternator",
+                                "spec/data/spec/queries/0/spec/query/spec/expr": "$func(rate(scylla_httpd_requests_served{service=~\"http.?-alternator\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]], service)"
+                            },
+                            {
+                                "span": 3,
+                                "class": "plain_text"
+                            },
+                            {
+                                "span": 3,
+                                "class": "rps_panel",
+                                "spec/title": "HTTP Read errors $func by [[by]]",
+                                "spec/description": "Rate of errors while reading Alternator HTTP requests",
+                                "spec/data/spec/queries/0/spec/query/spec/expr": "$func(rate(scylla_httpd_read_errors{service=~\"http.?-alternator\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]], service)"
+                            },
+                            {
+                                "span": 3,
+                                "class": "requestsps_panel",
+                                "spec/title": "HTTP Reply errors $func by [[by]]",
+                                "spec/description": "Rate of errors while replying to Alternator HTTP requests",
+                                "spec/data/spec/queries/0/spec/query/spec/expr": "$func(rate(scylla_httpd_reply_errors{service=~\"http.?-alternator\", instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]], service)"
                             },
                             {
                                 "dashversion": [

--- a/grafana/alternator.template.json
+++ b/grafana/alternator.template.json
@@ -718,7 +718,7 @@
                                 "class": "percentunit_panel",
                                 "spec/title": "Expression Cache hit ratio $func by [[by]]",
                                 "spec/description": "Alterantor expression cache",
-                                "spec/data/spec/queries/0/spec/query/spec/expr": "$func(rate(scylla_alternator_expression_cache_hits{cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]],expression)/($func(rate(scylla_alternator_expression_cache_hits{cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]],expression) + $func(rate(scylla_alternator_expression_cache_misses{cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]],expression))"
+                                "spec/data/spec/queries/0/spec/query/spec/expr": "$func(rate(scylla_alternator_expression_cache_hits{cluster=~\"$cluster|$^\", dc=~\"$dc\", instance=~\"[[node]]\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]],expression)/($func(rate(scylla_alternator_expression_cache_hits{cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]],expression) + $func(rate(scylla_alternator_expression_cache_misses{cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]],expression))"
                             },
                             {
                                 "dashversion": [
@@ -728,7 +728,27 @@
                                 "class": "graph_panel",
                                 "spec/title": "Expression Cache eviction rate $func by [[by]]",
                                 "spec/description": "Alterantor expression cache eviction rate",
-                                "spec/data/spec/queries/0/spec/query/spec/expr": "$func(rate(scylla_alternator_expression_cache_evictions{cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])"
+                                "spec/data/spec/queries/0/spec/query/spec/expr": "$func(rate(scylla_alternator_expression_cache_evictions{cluster=~\"$cluster|$^\", dc=~\"$dc\", instance=~\"[[node]]\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])"
+                            },
+                            {
+                                "dashversion": [
+                                    ">2025.4"
+                                ],
+                                "span": 3,
+                                "class": "ops_panel",
+                                "spec/title": "Authentication failures $func by [[by]]",
+                                "spec/description": "Alternator authentication failures",
+                                "spec/data/spec/queries/0/spec/query/spec/expr": "$func(rate(scylla_alternator_authentication_failures{cluster=~\"$cluster|$^\", dc=~\"$dc\", instance=~\"[[node]]\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])"
+                            },
+                            {
+                                "dashversion": [
+                                    ">2025.4"
+                                ],
+                                "span": 3,
+                                "class": "ops_panel",
+                                "spec/title": "Authorization failures $func by [[by]]",
+                                "spec/description": "Alternator authorization failures",
+                                "spec/data/spec/queries/0/spec/query/spec/expr": "$func(rate(scylla_alternator_authorization_failures{cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]\"}[$__rate_interval])) by ([[by]])"
                             }
                         ],
                         "hideHeader": true

--- a/grafana/alternator.template.json
+++ b/grafana/alternator.template.json
@@ -506,7 +506,13 @@
                                 "spec/data/spec/queries/0/spec/query/spec/expr": "$func(rate(scylla_alternator_operation{instance=~\"[[node]]\",cluster=~\"$cluster|$^\", dc=~\"$dc\", shard=~\"[[shard]]|$^\", op=\"GetRecords\"}[$__rate_interval])) by ([[by]])"
                             }
                         ]
-                    },
+                    }
+
+                ]
+            },
+
+            {
+                "rows": [
                     {
                         "class": "header_row",
                         "hideHeader": true,
@@ -517,16 +523,12 @@
                                 "spec/vizConfig/spec/options/mode": "html"
                             }
                         ]
-                    }
-                ]
-            },
-            {
-                "title": "$alternator_streams_latency_ops",
-                "collapse": false,
-                "repeat": "alternator_streams_latency_ops",
-                "rows": [
+                    },
                     {
                         "class": "row",
+                        "title": "$alternator_streams_latency_ops",
+                        "collapse": false,
+                        "repeat": "alternator_streams_latency_ops",
                         "panels": [
                             {
                                 "span": 3,

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -3307,7 +3307,7 @@
       "spec/title": "Tables",
       "gridPos": {
          "h": 12,
-         "w": 8
+         "w": 10
       },
       "spec/vizConfig/spec/options": {
          "showHeader": true,
@@ -3466,6 +3466,46 @@
                      "value": 120
                   }
                ]
+            },
+            {
+               "matcher": {
+                  "id": "byName",
+                  "options": "Value #F"
+               },
+               "properties": [
+                  {
+                     "id": "displayName",
+                     "value": "WCU"
+                  },
+                  {
+                     "id": "unit",
+                     "value": "sishort"
+                  },
+                  {
+                     "id": "custom.width",
+                     "value": 100
+                  }
+               ]
+            },
+            {
+               "matcher": {
+                  "id": "byName",
+                  "options": "Value #G"
+               },
+               "properties": [
+                  {
+                     "id": "displayName",
+                     "value": "RCU"
+                  },
+                  {
+                     "id": "unit",
+                     "value": "sishort"
+                  },
+                  {
+                     "id": "custom.width",
+                     "value": 100
+                  }
+               ]
             }
          ]
       },
@@ -3492,7 +3532,9 @@
                         "Value #B",
                         "Value #C",
                         "Value #D",
-                        "Value #E"
+                        "Value #E",
+                        "Value #F",
+                        "Value #G"
                      ]
                   }
                }
@@ -3607,6 +3649,50 @@
                   }
                },
                "refId": "E",
+               "hidden": false
+            }
+         },
+         {
+            "kind": "PanelQuery",
+            "spec": {
+               "query": {
+                  "kind": "DataQuery",
+                  "group": "prometheus",
+                  "version": "v0",
+                  "datasource": {
+                     "name": "prometheus"
+                  },
+                  "spec": {
+                     "expr": "sum(increase(scylla_alternator_table_wcu_total{ks=~\"alternator_.*\"}[$__range])) by (cf)",
+                     "instant": true,
+                     "range": false,
+                     "format": "table",
+                     "legendFormat": "__auto"
+                  }
+               },
+               "refId": "F",
+               "hidden": false
+            }
+         },
+         {
+            "kind": "PanelQuery",
+            "spec": {
+               "query": {
+                  "kind": "DataQuery",
+                  "group": "prometheus",
+                  "version": "v0",
+                  "datasource": {
+                     "name": "prometheus"
+                  },
+                  "spec": {
+                     "expr": "sum(increase(scylla_alternator_table_rcu_total{ks=~\"alternator_.*\"}[$__range])) by (cf)",
+                     "instant": true,
+                     "range": false,
+                     "format": "table",
+                     "legendFormat": "__auto"
+                  }
+               },
+               "refId": "G",
                "hidden": false
             }
          }

--- a/grafana/types.json
+++ b/grafana/types.json
@@ -1787,6 +1787,103 @@
       },
       "type": "text"
    },
+   "single_histogram_panel": {
+      "kind": "Panel",
+      "spec": {
+         "id": "auto",
+         "title": "",
+         "description": "",
+         "links": [],
+         "data": {
+            "kind": "QueryGroup",
+            "spec": {
+            "queries": [
+               {
+                  "kind": "PanelQuery",
+                  "spec": {
+                  "query": {
+                     "kind": "DataQuery",
+                     "version": "v0",
+                     "group": "prometheus",
+                     "datasource": {
+                        "name": "prometheus"
+                     },
+                     "spec": {
+                        "editorMode": "code",
+                        "expr": "",
+                        "legendFormat": "",
+                        "range": false,
+                        "instant": true,
+                        "exemplar": false,
+                        "format": "heatmap"
+                     }
+                  },
+                  "refId": "A",
+                  "hidden": false
+                  }
+               }
+            ],
+            "transformations": [],
+            "queryOptions": {}
+            }
+         },
+         "vizConfig": {
+            "kind": "VizConfig",
+            "group": "histogram",
+            "version": "13.0.3",
+            "spec": {
+            "options": {
+               "tooltip": {
+                  "mode": "multi",
+                  "sort": "none",
+                  "hideZeros": false
+               },
+               "legend": {
+                  "showLegend": false,
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "calcs": []
+               }
+            },
+            "fieldConfig": {
+               "defaults": {
+                  "custom": {
+                  "stacking": {
+                     "mode": "none",
+                     "group": "A"
+                  },
+                  "lineWidth": 1,
+                  "fillOpacity": 80,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "tooltip": false,
+                     "viz": false,
+                     "legend": false
+                  }
+                  },
+                  "color": {
+                  "mode": "palette-classic"
+                  },
+                  "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "value": null,
+                        "color": "green"
+                     },
+                     {
+                        "value": 80,
+                        "color": "red"
+                     }
+                  ]
+                  }
+               },
+               "overrides": []
+            }
+            }
+         }
+      }
+   },
    "text_header_panel": {
       "class": "text_panel",
       "style": {},


### PR DESCRIPTION
This PR adds multiple missing metrics to the Alternator dashboard
## scylla_alternator_requests_blocked_memory scylla_alternator_requests_shed
## scylla_httpd_read_errors/reply_errors
<img width="929" height="184" alt="image" src="https://github.com/user-attachments/assets/adc8ba3b-49e6-4db2-baff-e88964f07001" />

## scylla_alternator_table_rcu_total/scylla_alternator_table_wcu_total
<img width="153" height="132" alt="image" src="https://github.com/user-attachments/assets/5f0c7490-56fa-45dd-a34e-44a95f824a30" />

## scylla_alternator_batch_item_count_histogram
<img width="475" height="363" alt="image" src="https://github.com/user-attachments/assets/fe6238d4-cf03-4aa6-bce8-ec42888959ee" />

## scylla_alternator_authentication_failures/authorization_failures
<img width="910" height="348" alt="image" src="https://github.com/user-attachments/assets/a560106f-1b5f-4b1a-afea-caa0408bb747" />

Fixes #2871